### PR TITLE
fix: attack animations not playing in-game when pressing Z (#11)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -437,7 +437,14 @@ impl VmHost for Emulator {
                 ActionProp::Y => movie.y.to_string(),
                 ActionProp::Visible => (movie.visible as i32).to_string(),
                 ActionProp::CurrentFrame => {
-                    if movie.next_frame.is_none() && movie.playing {
+                    // When a frame change is pending (e.g. set by GotoFrame2 within
+                    // the same tick), report the pending target frame. Otherwise the
+                    // stale current frame would be returned, which breaks games that
+                    // read _currentframe right after redirecting a movie (e.g. the
+                    // attack-animation logic in EBBLADE / EMETAL).
+                    if let Some(nf) = movie.next_frame {
+                        (nf.max(0) as u32 + 1).to_string()
+                    } else if movie.playing {
                         (movie.frame as u32 + 2).to_string()
                     } else {
                         (movie.frame as u32 + 1).to_string()


### PR DESCRIPTION
## Summary

Fixes #11.

In several games (e.g. EBBLADE / "赤刃" and EMETAL / "钢铁风暴"), pressing Z in-game did not show any attack / projectile animation, even though the attack logic itself ran (sound effects played, state changed). Z worked fine in menus, and arrow-key movement was unaffected.

## Root cause

These games rebuild the player movie clip every tick with logic equivalent to:

```
temp = GetProperty("player", _currentframe)   // read current frame
RemoveSprite("player")
CloneSprite("playerMc", "player", ...)         // re-clone
GotoFrame2(temp)                               // restore to the frame just read
```

When Z is pressed, the game first redirects the player movie to the attack-animation frame via `GotoFrame2` (which sets the movie's pending `next_frame`). Immediately afterwards the snippet above reads `_currentframe`. The previous implementation of `get_property(CurrentFrame)` returned the **stale** current frame whenever a `next_frame` was pending, so the subsequent `GotoFrame2` overwrote the just-set attack frame and snapped the player back to the idle animation.

The net effect: the attack was triggered correctly, but the attack animation frame was immediately discarded, so nothing visible happened.

Menus work because there the button action performs a direct `GotoFrame` jump and does not go through the "read current frame, then restore" pattern.

## Fix

`get_property(CurrentFrame)` now reports the pending target frame when a frame change is queued (`next_frame` is `Some`), instead of the stale current frame. When no change is pending, behaviour is unchanged.

## Verification

- Traced the player movie frame around an attack input: before the fix it stayed in the idle range; after the fix it correctly advances through the attack-animation frames and returns to idle.
- Confirmed arrow-key movement and idle animation are unaffected.
- `cargo fmt`, `cargo clippy -- -D warnings` and `cargo test --all` all pass.