### PR TITLE
fix: fullscreen flag not working and scale not affecting game display

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ mod screen {
     type Display = *mut core::ffi::c_void;
     type Window = u64;
 
+    #[link(name = "X11")]
     extern "system" {
         fn XOpenDisplay(display_name: *const u8) -> Display;
         fn XCloseDisplay(display: Display) -> i32;
@@ -79,6 +80,7 @@ mod screen {
     // macOS Core Graphics FFI for querying main display resolution
     type CGDirectDisplayID = u32;
 
+    #[link(name = "CoreGraphics", kind = "framework")]
     extern "C" {
         fn CGMainDisplayID() -> CGDirectDisplayID;
         fn CGDisplayPixelsWide(display: CGDirectDisplayID) -> usize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,74 @@ mod sprite_system;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
+// Platform-specific screen resolution APIs for fullscreen mode
+
+#[cfg(target_os = "windows")]
+mod screen {
+    extern "system" {
+        fn GetSystemMetrics(nIndex: i32) -> i32;
+    }
+    const SM_CXSCREEN: i32 = 0;
+    const SM_CYSCREEN: i32 = 1;
+
+    pub fn get_screen_size() -> (usize, usize) {
+        unsafe {
+            (
+                GetSystemMetrics(SM_CXSCREEN) as usize,
+                GetSystemMetrics(SM_CYSCREEN) as usize,
+            )
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod screen {
+    // X11 FFI for querying display resolution
+    type Display = *mut core::ffi::c_void;
+    type Window = u64;
+
+    extern "system" {
+        fn XOpenDisplay(display_name: *const u8) -> Display;
+        fn XCloseDisplay(display: Display) -> i32;
+        fn XDefaultRootWindow(display: Display) -> Window;
+        fn XDisplayWidth(display: Display, screen_number: i32) -> i32;
+        fn XDisplayHeight(display: Display, screen_number: i32) -> i32;
+    }
+
+    pub fn get_screen_size() -> (usize, usize) {
+        unsafe {
+            let display = XOpenDisplay(std::ptr::null());
+            if display.is_null() {
+                return (800, 600);
+            }
+            let w = XDisplayWidth(display, 0) as usize;
+            let h = XDisplayHeight(display, 0) as usize;
+            let _ = XDefaultRootWindow(display);
+            let _ = XCloseDisplay(display);
+            (w, h)
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod screen {
+    // macOS Core Graphics FFI for querying main display resolution
+    type CGDirectDisplayID = u32;
+
+    extern "C" {
+        fn CGMainDisplayID() -> CGDirectDisplayID;
+        fn CGDisplayPixelsWide(display: CGDirectDisplayID) -> usize;
+        fn CGDisplayPixelsHigh(display: CGDirectDisplayID) -> usize;
+    }
+
+    pub fn get_screen_size() -> (usize, usize) {
+        unsafe {
+            let display = CGMainDisplayID();
+            (CGDisplayPixelsWide(display), CGDisplayPixelsHigh(display))
+        }
+    }
+}
+
 use anyhow::{Context, Result};
 use file_loader::{FrameObject, Native32Reader, ObjectType};
 use sprite_system::{MovieState, SpriteSystem};
@@ -75,9 +143,6 @@ impl Emulator {
         let resolution = reader.resolution;
         let colorspace = reader.colorspace;
 
-        let display_width = resolution.0 * scale;
-        let display_height = resolution.1 * scale;
-
         let mut input = InputHandler::new();
         input.remap(key_remappings);
 
@@ -90,7 +155,7 @@ impl Emulator {
             frame_player: FramePlayer::new(),
             vm: ActionVM::new(),
             audio: AudioEngine::new(colorspace, volume),
-            renderer: Renderer::new(display_width, display_height),
+            renderer: Renderer::new(resolution.0, resolution.1),
             input,
             save_manager,
             content_loader: ContentLoader::new(),
@@ -319,9 +384,13 @@ impl Emulator {
             .into_iter()
             .collect();
         let resolution = self.reader.resolution;
-        let w = resolution.0 * self.scale;
-        let h = resolution.1 * self.scale;
-        GamepadOverlay::draw(&mut self.renderer.buffer, w, h, self.scale, &pressed);
+        GamepadOverlay::draw(
+            &mut self.renderer.buffer,
+            resolution.0,
+            resolution.1,
+            self.scale,
+            &pressed,
+        );
     }
 
     /// Switch to new content (SSL multi-file).
@@ -653,21 +722,38 @@ fn main() -> Result<()> {
     let resolution = emu.reader.resolution;
     let display_width = resolution.0 * cli.scale;
     let display_height = resolution.1 * cli.scale;
+    let (buf_width, buf_height) = (resolution.0, resolution.1);
+
+    // For fullscreen, get screen resolution before creating the window
+    // so minifb creates the window at the correct size from the start.
+    let (window_width, window_height) = if cli.fullscreen {
+        let (sw, sh) = screen::get_screen_size();
+        (sw, sh)
+    } else {
+        (display_width as usize, display_height as usize)
+    };
 
     // Create window
     let window_opts = minifb::WindowOptions {
-        resize: true,
+        resize: !cli.fullscreen,
+        borderless: cli.fullscreen,
         scale_mode: minifb::ScaleMode::AspectRatioStretch,
         ..Default::default()
     };
 
     let mut window = minifb::Window::new(
         "Native32 Emulator",
-        display_width as usize,
-        display_height as usize,
+        window_width,
+        window_height,
         window_opts,
     )
     .context("Failed to create window")?;
+
+    // Apply fullscreen settings
+    if cli.fullscreen {
+        window.topmost(true);
+        window.set_position(0, 0);
+    }
 
     // Limit to 30fps
     window.set_target_fps(30);
@@ -697,8 +783,8 @@ fn main() -> Result<()> {
         window
             .update_with_buffer(
                 &emu.renderer.buffer,
-                display_width as usize,
-                display_height as usize,
+                buf_width as usize,
+                buf_height as usize,
             )
             .context("Failed to update display")?;
 


### PR DESCRIPTION
## Problem

Closes #13

### 1. `-f` / `--fullscreen` flag has no effect

The `--fullscreen` CLI flag was declared in `cli.rs` but its value was never read in the window creation code in `main.rs`. Running with `-f` produced a normal windowed window.

### 2. `--scale` makes window larger but game content stays small

The `--scale` factor was multiplied into both the renderer buffer dimensions AND the window size. The game drew objects at their original (unscaled) coordinates into a buffer that was now 2x (or Nx) larger, so the game content only filled the top-left quarter of the buffer. minifb then displayed this oversized buffer, resulting in a large window with tiny content.

## Fix

### Fullscreen (cross-platform)

Added a `screen` module with platform-specific screen resolution detection via FFI:
- **Windows**: `GetSystemMetrics(SM_CXSCREEN/SM_CYSCREEN)` (Win32 API)
- **Linux**: `XDisplayWidth`/`XDisplayHeight` (X11 FFI)
- **macOS**: `CGDisplayPixelsWide`/`CGDisplayPixelsHigh` (Core Graphics FFI)

Screen resolution is queried **before** window creation so minifb creates the window at the correct size from the start. The window is also set to `borderless` + `topmost` + positioned at (0,0).

### Scale

Separated "buffer resolution" from "window size":
- **Buffer**: Always created at the game's original resolution (`Renderer::new(resolution.0, resolution.1)`)
- **Window**: Sized to `resolution * scale`
- **Rendering**: minifb's `AspectRatioStretch` mode scales the small buffer to fill the larger window

`update_with_buffer` now receives the original (unscaled) buffer dimensions, letting minifb handle the actual display scaling.

## Testing

```bash
# Fullscreen
cargo run --release -- -f native32_game/EACT/EBBLADE.smf

# Scale 2x
cargo run --release -- --scale 2 native32_game/EACT/EBBLADE.smf
```