### PR TITLE
test: add comprehensive unit tests for all core emulator modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,7 @@ dependencies = [
  "minifb",
  "rand 0.10.1",
  "rodio",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ env_logger = { version = "0.11", optional = true }
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["precommit-hook", "run-cargo-fmt", "run-cargo-clippy"] }
+tempfile = "3"
 
 [features]
 default = ["standalone"]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,5 @@ sonar.organization=jiangxincode-github
 sonar.sources=src
 sonar.exclusions=**/target/**
 sonar.sourceEncoding=UTF-8
+
+sonar.coverageReportPaths=coverage/cobertura.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,5 @@ sonar.organization=jiangxincode-github
 sonar.sources=src
 sonar.exclusions=**/target/**
 sonar.sourceEncoding=UTF-8
+
+sonar.rust.cobertura.reportPaths=coverage/cobertura.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,5 +5,3 @@ sonar.organization=jiangxincode-github
 sonar.sources=src
 sonar.exclusions=**/target/**
 sonar.sourceEncoding=UTF-8
-
-sonar.coverageReportPaths=coverage/cobertura.xml

--- a/src/core/action_vm.rs
+++ b/src/core/action_vm.rs
@@ -8,7 +8,7 @@ use rand::RngExt;
 use crate::core::actions::Action;
 use crate::core::file_loader::{ActionPayload, Native32Reader};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u32)]
 pub enum ActionProp {
     X = 0,
@@ -438,5 +438,785 @@ impl ActionVM {
 
             pc = npc;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::file_loader::Native32Reader;
+
+    // === Helper functions ===
+
+    fn parse_float(s: &str) -> f64 {
+        s.parse::<f64>().unwrap_or(0.0)
+    }
+
+    /// Mock VmHost that records calls for verification.
+    struct MockHost {
+        stopped: bool,
+        played: bool,
+        frame: u32,
+        goto_calls: Vec<(String, u32, bool)>,
+        properties: std::collections::HashMap<(String, ActionProp), String>,
+        cloned: Vec<(String, String, i32)>,
+        removed: Vec<String>,
+        stop_sounds_called: bool,
+        time: u32,
+    }
+
+    impl MockHost {
+        fn new() -> Self {
+            Self {
+                stopped: false,
+                played: false,
+                frame: 1,
+                goto_calls: Vec::new(),
+                properties: std::collections::HashMap::new(),
+                cloned: Vec::new(),
+                removed: Vec::new(),
+                stop_sounds_called: false,
+                time: 0,
+            }
+        }
+    }
+
+    impl VmHost for MockHost {
+        fn stop(&mut self, _target: &str) {
+            self.stopped = true;
+        }
+        fn play(&mut self, _target: &str) {
+            self.played = true;
+        }
+        fn get_frame(&mut self, _target: &str) -> u32 {
+            self.frame
+        }
+        fn goto_frame(&mut self, target: &str, frame: u32, playing: bool) {
+            self.goto_calls.push((target.to_string(), frame, playing));
+        }
+        fn stop_sounds(&mut self, _target: &str) {
+            self.stop_sounds_called = true;
+        }
+        fn set_property(&mut self, target: &str, prop: ActionProp, value: &str) {
+            self.properties
+                .insert((target.to_string(), prop), value.to_string());
+        }
+        fn get_property(&mut self, target: &str, prop: ActionProp) -> String {
+            self.properties
+                .get(&(target.to_string(), prop))
+                .cloned()
+                .unwrap_or_else(|| "0".to_string())
+        }
+        fn clone_sprite(&mut self, src: &str, dest: &str, depth: i32) {
+            self.cloned.push((src.to_string(), dest.to_string(), depth));
+        }
+        fn remove_sprite(&mut self, name: &str) {
+            self.removed.push(name.to_string());
+        }
+        fn call(&mut self, _frame: u32) {}
+        fn get_time(&self) -> u32 {
+            self.time
+        }
+        fn get_url(&mut self, _url: &str, _target: &str) {}
+        fn run_frame_actions(&mut self, _frame: u32) {}
+    }
+
+    /// Build a Native32Reader with pre-loaded action bytecode for testing.
+    ///
+    /// Layout:
+    ///   base = 0x60
+    ///   actions start at buffer offset 0x60 (action_idx = 0 relative to base)
+    ///   each action = 8 bytes: opcode(u32 LE) + payload(u32 LE)
+    ///   payload string data placed after all actions
+    fn make_test_reader(actions: &[(Action, Option<ActionPayload>)]) -> Native32Reader {
+        let base = 0x60usize;
+        let action_count = actions.len();
+        // Each action: 8 bytes instruction + up to 64 bytes string payload
+        let data_size = base + action_count * 8 + action_count * 64 + 128;
+        let mut data = vec![0u8; data_size];
+
+        // Place actions
+        for (i, (op, payload)) in actions.iter().enumerate() {
+            let offset = base + i * 8;
+            data[offset..offset + 4].copy_from_slice(&(*op as u32).to_le_bytes());
+            match payload {
+                None => {}
+                Some(ActionPayload::Integer(val)) => {
+                    // For integer payloads, write the i16 value directly at a known location
+                    // Place it right after the action table
+                    let payload_offset = base + action_count * 8 + i * 4;
+                    data[payload_offset..payload_offset + 2].copy_from_slice(&val.to_le_bytes());
+                    let rel_offset = (payload_offset - base) as u32;
+                    data[offset + 4..offset + 8].copy_from_slice(&rel_offset.to_le_bytes());
+                }
+                Some(ActionPayload::String(s)) => {
+                    // Place string after the action table
+                    let payload_offset = base + action_count * 8 + i * 64;
+                    let bytes = s.as_bytes();
+                    data[payload_offset..payload_offset + bytes.len()].copy_from_slice(bytes);
+                    data[payload_offset + bytes.len()] = 0; // null terminator
+                    let rel_offset = (payload_offset - base) as u32;
+                    data[offset + 4..offset + 8].copy_from_slice(&rel_offset.to_le_bytes());
+                }
+            }
+        }
+
+        let mut reader = Native32Reader::new(data);
+        reader.base = base;
+        reader
+    }
+
+    /// Run VM with given actions and return the mock host for inspection.
+    fn run_vm(actions: &[(Action, Option<ActionPayload>)]) -> MockHost {
+        let mut reader = make_test_reader(actions);
+        let mut vm = ActionVM::new();
+        let mut host = MockHost::new();
+        vm.run(&mut reader, &mut host, 1, "");
+        host
+    }
+
+    fn run_vm_vars(actions: &[(Action, Option<ActionPayload>)]) -> (ActionVM, MockHost) {
+        let mut reader = make_test_reader(actions);
+        let mut vm = ActionVM::new();
+        let mut host = MockHost::new();
+        vm.run(&mut reader, &mut host, 1, "");
+        (vm, host)
+    }
+
+    /// Helper: compute with 2 operands, store result in variable `r`.
+    /// The pattern is: Push "r", Push a, Push b, Op, SetVariable, End
+    fn compute_2op(a: &str, b: &str, op: Action) -> ActionVM {
+        let (vm, _) = run_vm_vars(&[
+            (Action::Push, Some(ActionPayload::String("r".to_string()))),
+            (Action::Push, Some(ActionPayload::String(a.to_string()))),
+            (Action::Push, Some(ActionPayload::String(b.to_string()))),
+            (op, None),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        vm
+    }
+
+    /// Helper: compute with 1 operand, store result in variable `r`.
+    fn compute_1op(a: &str, op: Action) -> ActionVM {
+        let (vm, _) = run_vm_vars(&[
+            (Action::Push, Some(ActionPayload::String("r".to_string()))),
+            (Action::Push, Some(ActionPayload::String(a.to_string()))),
+            (op, None),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        vm
+    }
+
+    /// Helper: set var to val_a, then compute val_a op val_b, store in `r`.
+    fn compute_2op_with_var(var: &str, val_a: &str, val_b: &str, op: Action) -> ActionVM {
+        let (vm, _) = run_vm_vars(&[
+            // Set var = val_a
+            (Action::Push, Some(ActionPayload::String(var.to_string()))),
+            (Action::Push, Some(ActionPayload::String(val_a.to_string()))),
+            (Action::SetVariable, None),
+            // Push "r", get var, push val_b, op, set r
+            (Action::Push, Some(ActionPayload::String("r".to_string()))),
+            (Action::Push, Some(ActionPayload::String(var.to_string()))),
+            (Action::GetVariable, None),
+            (Action::Push, Some(ActionPayload::String(val_b.to_string()))),
+            (op, None),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        vm
+    }
+
+    // === Pure helper function tests ===
+
+    #[test]
+    fn test_str_to_float_valid() {
+        assert_eq!(str_to_float("3.14"), 3.14);
+        assert_eq!(str_to_float("0"), 0.0);
+        assert_eq!(str_to_float("-1.5"), -1.5);
+    }
+
+    #[test]
+    fn test_str_to_float_empty() {
+        assert_eq!(str_to_float(""), 0.0);
+    }
+
+    #[test]
+    fn test_str_to_float_invalid() {
+        assert_eq!(str_to_float("abc"), 0.0);
+    }
+
+    #[test]
+    fn test_str_to_int_valid() {
+        assert_eq!(str_to_int("42"), 42);
+        assert_eq!(str_to_int("3.9"), 3); // truncated
+        assert_eq!(str_to_int("-10"), -10);
+    }
+
+    #[test]
+    fn test_str_to_int_empty() {
+        assert_eq!(str_to_int(""), 0);
+    }
+
+    #[test]
+    fn test_to_string_fn() {
+        assert_eq!(to_string(42), "42");
+        assert_eq!(to_string(3.14f64), "3.14");
+        assert_eq!(to_string("hello"), "hello");
+    }
+
+    #[test]
+    fn test_action_prop_from_u32() {
+        assert_eq!(ActionProp::from_u32(0), Some(ActionProp::X));
+        assert_eq!(ActionProp::from_u32(1), Some(ActionProp::Y));
+        assert_eq!(ActionProp::from_u32(4), Some(ActionProp::CurrentFrame));
+        assert_eq!(ActionProp::from_u32(7), Some(ActionProp::Visible));
+        assert_eq!(ActionProp::from_u32(13), Some(ActionProp::Name));
+        assert_eq!(ActionProp::from_u32(10), None); // unused
+        assert_eq!(ActionProp::from_u32(99), None);
+    }
+
+    // === VM opcode tests ===
+    //
+    // SetVariable semantics: pops val (top), pops var_name (second), inserts vars[var] = val.
+    // Correct pattern: Push var_name, ..., Push value, SetVariable
+    // For computed values: Push var_name, Push operands, Op, SetVariable
+
+    // --- Stack operations ---
+
+    #[test]
+    fn test_vm_end_immediately() {
+        let (vm, _) = run_vm_vars(&[(Action::End, None)]);
+        assert!(vm.vars.is_empty());
+    }
+
+    #[test]
+    fn test_vm_push_string_and_set() {
+        // Push var name, push value, SetVariable
+        let (vm, _) = run_vm_vars(&[
+            (Action::Push, Some(ActionPayload::String("x".to_string()))),
+            (
+                Action::Push,
+                Some(ActionPayload::String("hello".to_string())),
+            ),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(vm.vars.get("x"), Some(&"hello".to_string()));
+    }
+
+    #[test]
+    fn test_vm_push_integer_and_set() {
+        // Push always reads string payload from the reader (even for Integer variant,
+        // the reader's disassemble_action treats Push as string). Use String("42").
+        let (vm, _) = run_vm_vars(&[
+            (Action::Push, Some(ActionPayload::String("x".to_string()))),
+            (Action::Push, Some(ActionPayload::String("42".to_string()))),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(vm.vars.get("x"), Some(&"42".to_string()));
+    }
+
+    #[test]
+    fn test_vm_pop() {
+        // Push a, Push b, Pop (removes b), Push var, Push a (still on stack? no, pop removed b)
+        // Actually: Push "a", Push "b", Pop → stack: ["a"]
+        // Then Push "v", Push "a" is gone... let me rethink.
+        // Simple: Push "keep", Push "discard", Pop, Push "v", SetVariable
+        // Stack after Push "keep": ["keep"]
+        // Stack after Push "discard": ["keep", "discard"]
+        // Stack after Pop: ["keep"]
+        // Stack after Push "v": ["keep", "v"]
+        // SetVariable: val = "v", var = "keep" → vars["keep"] = "v"
+        let (vm, _) = run_vm_vars(&[
+            (
+                Action::Push,
+                Some(ActionPayload::String("keep".to_string())),
+            ),
+            (
+                Action::Push,
+                Some(ActionPayload::String("discard".to_string())),
+            ),
+            (Action::Pop, None),
+            (Action::Push, Some(ActionPayload::String("v".to_string()))),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(vm.vars.get("keep"), Some(&"v".to_string()));
+    }
+
+    // --- Arithmetic ---
+
+    #[test]
+    fn test_vm_add() {
+        let vm = compute_2op("3", "5", Action::Add);
+        assert_eq!(vm.vars.get("r"), Some(&"8".to_string()));
+    }
+
+    #[test]
+    fn test_vm_subtract() {
+        let vm = compute_2op("10", "3", Action::Subtract);
+        assert_eq!(vm.vars.get("r"), Some(&"7".to_string()));
+    }
+
+    #[test]
+    fn test_vm_multiply() {
+        let vm = compute_2op("4", "5", Action::Multiply);
+        assert_eq!(vm.vars.get("r"), Some(&"20".to_string()));
+    }
+
+    #[test]
+    fn test_vm_divide() {
+        let vm = compute_2op("20", "4", Action::Divide);
+        assert_eq!(vm.vars.get("r"), Some(&"5".to_string()));
+    }
+
+    #[test]
+    fn test_vm_divide_by_zero() {
+        let vm = compute_2op("10", "0", Action::Divide);
+        assert_eq!(vm.vars.get("r"), Some(&"0".to_string()));
+    }
+
+    // --- Comparison ---
+
+    #[test]
+    fn test_vm_equals_true() {
+        let vm = compute_2op("5", "5", Action::Equals);
+        assert_eq!(vm.vars.get("r"), Some(&"1".to_string()));
+    }
+
+    #[test]
+    fn test_vm_equals_false() {
+        let vm = compute_2op("5", "6", Action::Equals);
+        assert_eq!(vm.vars.get("r"), Some(&"0".to_string()));
+    }
+
+    #[test]
+    fn test_vm_less_true() {
+        let vm = compute_2op("3", "5", Action::Less);
+        assert_eq!(vm.vars.get("r"), Some(&"1".to_string()));
+    }
+
+    #[test]
+    fn test_vm_less_false() {
+        let vm = compute_2op("5", "3", Action::Less);
+        assert_eq!(vm.vars.get("r"), Some(&"0".to_string()));
+    }
+
+    // --- Logic ---
+
+    #[test]
+    fn test_vm_and_both_true() {
+        let vm = compute_2op("1", "1", Action::And);
+        assert_eq!(vm.vars.get("r"), Some(&"1".to_string()));
+    }
+
+    #[test]
+    fn test_vm_and_one_false() {
+        let vm = compute_2op("1", "0", Action::And);
+        assert_eq!(vm.vars.get("r"), Some(&"0".to_string()));
+    }
+
+    #[test]
+    fn test_vm_or() {
+        let vm = compute_2op("0", "1", Action::Or);
+        assert_eq!(vm.vars.get("r"), Some(&"1".to_string()));
+    }
+
+    #[test]
+    fn test_vm_not_true() {
+        let vm = compute_1op("0", Action::Not);
+        assert_eq!(vm.vars.get("r"), Some(&"1".to_string()));
+    }
+
+    #[test]
+    fn test_vm_not_false() {
+        let vm = compute_1op("42", Action::Not);
+        assert_eq!(vm.vars.get("r"), Some(&"0".to_string()));
+    }
+
+    // --- String operations ---
+
+    #[test]
+    fn test_vm_string_equals() {
+        let vm = compute_2op("abc", "abc", Action::StringEquals);
+        assert_eq!(vm.vars.get("r"), Some(&"1".to_string()));
+    }
+
+    #[test]
+    fn test_vm_string_equals_different() {
+        let vm = compute_2op("abc", "def", Action::StringEquals);
+        assert_eq!(vm.vars.get("r"), Some(&"0".to_string()));
+    }
+
+    #[test]
+    fn test_vm_string_add() {
+        let vm = compute_2op("hello", " world", Action::StringAdd);
+        assert_eq!(vm.vars.get("r"), Some(&"hello world".to_string()));
+    }
+
+    #[test]
+    fn test_vm_string_length() {
+        let vm = compute_1op("hello", Action::StringLength);
+        assert_eq!(vm.vars.get("r"), Some(&"5".to_string()));
+    }
+
+    #[test]
+    fn test_vm_string_extract() {
+        // StringExtract: pop len, pop start, pop string → push substring
+        // "hello", start=2, len=3 → "ell" (1-indexed)
+        // Stack order for StringExtract: [string, start, len] with len on top
+        let (vm, _) = run_vm_vars(&[
+            (Action::Push, Some(ActionPayload::String("r".to_string()))),
+            (
+                Action::Push,
+                Some(ActionPayload::String("hello".to_string())),
+            ),
+            (Action::Push, Some(ActionPayload::String("2".to_string()))),
+            (Action::Push, Some(ActionPayload::String("3".to_string()))),
+            (Action::StringExtract, None),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(vm.vars.get("r"), Some(&"ell".to_string()));
+    }
+
+    #[test]
+    fn test_vm_string_less() {
+        let vm = compute_2op("abc", "def", Action::StringLess);
+        assert_eq!(vm.vars.get("r"), Some(&"1".to_string()));
+    }
+
+    // --- Type conversion ---
+
+    #[test]
+    fn test_vm_to_integer() {
+        let vm = compute_1op("3.14", Action::ToInteger);
+        assert_eq!(vm.vars.get("r"), Some(&"3".to_string()));
+    }
+
+    #[test]
+    fn test_vm_char_to_ascii() {
+        let vm = compute_1op("A", Action::CharToAscii);
+        assert_eq!(vm.vars.get("r"), Some(&"65".to_string()));
+    }
+
+    #[test]
+    fn test_vm_ascii_to_char() {
+        let vm = compute_1op("65", Action::AsciiToChar);
+        assert_eq!(vm.vars.get("r"), Some(&"A".to_string()));
+    }
+
+    // --- Variable operations ---
+
+    #[test]
+    fn test_vm_set_and_get_variable() {
+        // Set score=42, then verify it's stored
+        let (vm, _) = run_vm_vars(&[
+            (
+                Action::Push,
+                Some(ActionPayload::String("score".to_string())),
+            ),
+            (Action::Push, Some(ActionPayload::String("42".to_string()))),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(vm.vars.get("score"), Some(&"42".to_string()));
+    }
+
+    #[test]
+    fn test_vm_get_variable_pushes_onto_stack() {
+        // Set score=42, get score, use in Add with 8 → 50
+        let vm = compute_2op_with_var("score", "42", "8", Action::Add);
+        assert_eq!(vm.vars.get("r"), Some(&"50".to_string()));
+    }
+
+    #[test]
+    fn test_vm_get_undefined_variable_pushes_empty() {
+        // GetVariable for undefined var → pushes "" → StringLength → 0
+        let (vm, _) = run_vm_vars(&[
+            (Action::Push, Some(ActionPayload::String("r".to_string()))),
+            (
+                Action::Push,
+                Some(ActionPayload::String("nonexistent".to_string())),
+            ),
+            (Action::GetVariable, None),  // pushes ""
+            (Action::StringLength, None), // "" → length 0
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(vm.vars.get("r"), Some(&"0".to_string()));
+    }
+
+    // --- Control flow ---
+
+    #[test]
+    fn test_vm_if_true_branches() {
+        // Push 1 (true), If with offset=1 → skip next instruction
+        let (vm, _) = run_vm_vars(&[
+            (Action::Push, Some(ActionPayload::String("r".to_string()))),
+            (Action::Push, Some(ActionPayload::String("1".to_string()))),
+            (Action::If, Some(ActionPayload::Integer(1))), // true, skip 1
+            (
+                Action::Push,
+                Some(ActionPayload::String("skipped".to_string())),
+            ), // skipped
+            (
+                Action::Push,
+                Some(ActionPayload::String("reached".to_string())),
+            ), // reached
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(vm.vars.get("r"), Some(&"reached".to_string()));
+    }
+
+    #[test]
+    fn test_vm_if_false_falls_through() {
+        let (vm, _) = run_vm_vars(&[
+            (Action::Push, Some(ActionPayload::String("r".to_string()))),
+            (Action::Push, Some(ActionPayload::String("0".to_string()))),
+            (Action::If, Some(ActionPayload::Integer(1))), // false, don't branch
+            (
+                Action::Push,
+                Some(ActionPayload::String("reached".to_string())),
+            ),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(vm.vars.get("r"), Some(&"reached".to_string()));
+    }
+
+    #[test]
+    fn test_vm_jump() {
+        let (vm, _) = run_vm_vars(&[
+            (Action::Push, Some(ActionPayload::String("r".to_string()))),
+            (Action::Jump, Some(ActionPayload::Integer(1))),
+            (
+                Action::Push,
+                Some(ActionPayload::String("skipped".to_string())),
+            ),
+            (
+                Action::Push,
+                Some(ActionPayload::String("reached".to_string())),
+            ),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(vm.vars.get("r"), Some(&"reached".to_string()));
+    }
+
+    // --- Host interaction ---
+
+    #[test]
+    fn test_vm_stop() {
+        let host = run_vm(&[(Action::Stop, None), (Action::End, None)]);
+        assert!(host.stopped);
+    }
+
+    #[test]
+    fn test_vm_play() {
+        let host = run_vm(&[(Action::Play, None), (Action::End, None)]);
+        assert!(host.played);
+    }
+
+    #[test]
+    fn test_vm_stop_sounds() {
+        let host = run_vm(&[(Action::StopSounds, None), (Action::End, None)]);
+        assert!(host.stop_sounds_called);
+    }
+
+    #[test]
+    fn test_vm_next_frame() {
+        let host = run_vm(&[(Action::NextFrame, None), (Action::End, None)]);
+        assert_eq!(host.goto_calls.len(), 1);
+        assert_eq!(host.goto_calls[0].1, 2); // current_frame(1) + 1
+    }
+
+    #[test]
+    fn test_vm_previous_frame() {
+        let host = run_vm(&[(Action::PreviousFrame, None), (Action::End, None)]);
+        assert_eq!(host.goto_calls.len(), 1);
+        assert_eq!(host.goto_calls[0].1, 0); // 1 - 1
+    }
+
+    #[test]
+    fn test_vm_previous_frame_at_zero() {
+        let mut reader = make_test_reader(&[(Action::PreviousFrame, None), (Action::End, None)]);
+        let mut vm = ActionVM::new();
+        let mut host = MockHost::new();
+        host.frame = 0;
+        vm.run(&mut reader, &mut host, 1, "");
+        assert_eq!(host.goto_calls[0].1, 0); // saturating_sub
+    }
+
+    #[test]
+    fn test_vm_goto_frame() {
+        let host = run_vm(&[
+            (Action::GotoFrame, Some(ActionPayload::Integer(9))),
+            (Action::End, None),
+        ]);
+        assert_eq!(host.goto_calls.len(), 1);
+        assert_eq!(host.goto_calls[0].1, 10); // frame + 1 (1-based)
+    }
+
+    #[test]
+    fn test_vm_goto_frame2() {
+        let host = run_vm(&[
+            (Action::Push, Some(ActionPayload::String("5".to_string()))),
+            (Action::GotoFrame2, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(host.goto_calls.len(), 1);
+        assert_eq!(host.goto_calls[0].1, 5);
+    }
+
+    #[test]
+    fn test_vm_clone_sprite() {
+        let host = run_vm(&[
+            (Action::Push, Some(ActionPayload::String("src".to_string()))),
+            (
+                Action::Push,
+                Some(ActionPayload::String("dest".to_string())),
+            ),
+            (Action::Push, Some(ActionPayload::String("10".to_string()))),
+            (Action::CloneSprite, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(host.cloned.len(), 1);
+        assert_eq!(host.cloned[0], ("src".to_string(), "dest".to_string(), 10));
+    }
+
+    #[test]
+    fn test_vm_remove_sprite() {
+        let host = run_vm(&[
+            (
+                Action::Push,
+                Some(ActionPayload::String("target".to_string())),
+            ),
+            (Action::RemoveSprite, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(host.removed, vec!["target"]);
+    }
+
+    // --- Edge cases ---
+
+    #[test]
+    fn test_vm_empty_actions() {
+        let (vm, _) = run_vm_vars(&[]);
+        assert!(vm.vars.is_empty());
+    }
+
+    #[test]
+    fn test_vm_pop_empty_stack() {
+        let (vm, _) = run_vm_vars(&[(Action::Pop, None), (Action::End, None)]);
+        assert!(vm.vars.is_empty());
+    }
+
+    #[test]
+    fn test_vm_set_variable_empty_stack() {
+        let (vm, _) = run_vm_vars(&[(Action::SetVariable, None), (Action::End, None)]);
+        assert_eq!(vm.vars.get(""), Some(&"".to_string()));
+    }
+
+    #[test]
+    fn test_vm_set_target() {
+        let mut reader = make_test_reader(&[
+            (
+                Action::SetTarget,
+                Some(ActionPayload::String("movie1".to_string())),
+            ),
+            (Action::Stop, None),
+            (Action::End, None),
+        ]);
+        let mut vm = ActionVM::new();
+        let mut host = MockHost::new();
+        vm.run(&mut reader, &mut host, 1, "");
+        assert!(host.stopped);
+    }
+
+    #[test]
+    fn test_vm_set_target2() {
+        let mut reader = make_test_reader(&[
+            (
+                Action::Push,
+                Some(ActionPayload::String("movie2".to_string())),
+            ),
+            (Action::SetTarget2, None),
+            (Action::Play, None),
+            (Action::End, None),
+        ]);
+        let mut vm = ActionVM::new();
+        let mut host = MockHost::new();
+        vm.run(&mut reader, &mut host, 1, "");
+        assert!(host.played);
+    }
+
+    #[test]
+    fn test_vm_get_time() {
+        let mut reader = make_test_reader(&[
+            (Action::Push, Some(ActionPayload::String("r".to_string()))),
+            (Action::GetTime, None),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        let mut vm = ActionVM::new();
+        let mut host = MockHost::new();
+        host.time = 12345;
+        vm.run(&mut reader, &mut host, 1, "");
+        assert_eq!(vm.vars.get("r"), Some(&"12345".to_string()));
+    }
+
+    #[test]
+    fn test_vm_random_number() {
+        // RandomNumber(10) should return 0..9
+        let vm = compute_1op("10", Action::RandomNumber);
+        let val: i64 = vm.vars.get("r").unwrap().parse().unwrap();
+        assert!(val >= 0 && val < 10);
+    }
+
+    #[test]
+    fn test_vm_random_number_zero() {
+        let vm = compute_1op("0", Action::RandomNumber);
+        assert_eq!(vm.vars.get("r"), Some(&"0".to_string()));
+    }
+
+    // --- Complex sequences ---
+
+    #[test]
+    fn test_vm_arithmetic_chain() {
+        // (3 + 5) * 2 = 16
+        // Push "r", Push 3, Push 5, Add → ["r", 8], Push 2, Multiply → ["r", 16], SetVariable
+        let (vm, _) = run_vm_vars(&[
+            (Action::Push, Some(ActionPayload::String("r".to_string()))),
+            (Action::Push, Some(ActionPayload::String("3".to_string()))),
+            (Action::Push, Some(ActionPayload::String("5".to_string()))),
+            (Action::Add, None),
+            (Action::Push, Some(ActionPayload::String("2".to_string()))),
+            (Action::Multiply, None),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(vm.vars.get("r"), Some(&"16".to_string()));
+    }
+
+    #[test]
+    fn test_vm_conditional_logic() {
+        // if (3 < 5) then x=1 else x=0
+        let (vm, _) = run_vm_vars(&[
+            (Action::Push, Some(ActionPayload::String("x".to_string()))),
+            (Action::Push, Some(ActionPayload::String("3".to_string()))),
+            (Action::Push, Some(ActionPayload::String("5".to_string()))),
+            (Action::Less, None),                          // 3 < 5 → 1
+            (Action::If, Some(ActionPayload::Integer(1))), // true, skip 1
+            (Action::Push, Some(ActionPayload::String("0".to_string()))), // skipped
+            (Action::Push, Some(ActionPayload::String("1".to_string()))),
+            (Action::SetVariable, None),
+            (Action::End, None),
+        ]);
+        assert_eq!(vm.vars.get("x"), Some(&"1".to_string()));
     }
 }

--- a/src/core/action_vm.rs
+++ b/src/core/action_vm.rs
@@ -632,7 +632,7 @@ mod tests {
 
     #[test]
     fn test_str_to_float_valid() {
-        assert_eq!(str_to_float("3.14"), 3.14);
+        assert_eq!(str_to_float("3.25"), 3.25);
         assert_eq!(str_to_float("0"), 0.0);
         assert_eq!(str_to_float("-1.5"), -1.5);
     }
@@ -662,7 +662,7 @@ mod tests {
     #[test]
     fn test_to_string_fn() {
         assert_eq!(to_string(42), "42");
-        assert_eq!(to_string(3.14f64), "3.14");
+        assert_eq!(to_string(3.25f64), "3.25");
         assert_eq!(to_string("hello"), "hello");
     }
 
@@ -1175,7 +1175,7 @@ mod tests {
         // RandomNumber(10) should return 0..9
         let vm = compute_1op("10", Action::RandomNumber);
         let val: i64 = vm.vars.get("r").unwrap().parse().unwrap();
-        assert!(val >= 0 && val < 10);
+        assert!((0..10).contains(&val));
     }
 
     #[test]

--- a/src/core/actions.rs
+++ b/src/core/actions.rs
@@ -115,3 +115,97 @@ impl Action {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_known_opcodes_roundtrip() {
+        // Every defined opcode should map to Some
+        let cases: &[(u32, Action)] = &[
+            (0x00, Action::End),
+            (0x04, Action::NextFrame),
+            (0x05, Action::PreviousFrame),
+            (0x06, Action::Play),
+            (0x07, Action::Stop),
+            (0x09, Action::StopSounds),
+            (0x0a, Action::Add),
+            (0x0b, Action::Subtract),
+            (0x0c, Action::Multiply),
+            (0x0d, Action::Divide),
+            (0x0e, Action::Equals),
+            (0x0f, Action::Less),
+            (0x10, Action::And),
+            (0x11, Action::Or),
+            (0x12, Action::Not),
+            (0x13, Action::StringEquals),
+            (0x14, Action::StringLength),
+            (0x15, Action::StringExtract),
+            (0x17, Action::Pop),
+            (0x18, Action::ToInteger),
+            (0x1c, Action::GetVariable),
+            (0x1d, Action::SetVariable),
+            (0x20, Action::SetTarget2),
+            (0x21, Action::StringAdd),
+            (0x22, Action::GetProperty),
+            (0x23, Action::SetProperty),
+            (0x24, Action::CloneSprite),
+            (0x25, Action::RemoveSprite),
+            (0x26, Action::Trace),
+            (0x27, Action::StartDrag),
+            (0x28, Action::EndDrag),
+            (0x29, Action::StringLess),
+            (0x30, Action::RandomNumber),
+            (0x31, Action::MBStringLength),
+            (0x32, Action::CharToAscii),
+            (0x33, Action::AsciiToChar),
+            (0x34, Action::GetTime),
+            (0x35, Action::MBStringExtract),
+            (0x36, Action::MBCharToAscii),
+            (0x37, Action::MBAsciiToChar),
+            (0x81, Action::GotoFrame),
+            (0x8a, Action::WaitForFrame),
+            (0x8b, Action::SetTarget),
+            (0x8c, Action::GotoLabel),
+            (0x8d, Action::WaitForFrame2),
+            (0x96, Action::Push),
+            (0x99, Action::Jump),
+            (0x9a, Action::GetUrl2),
+            (0x9d, Action::If),
+            (0x9e, Action::Call),
+            (0x9f, Action::GotoFrame2),
+        ];
+        for &(val, expected) in cases {
+            assert_eq!(
+                Action::from_u32(val),
+                Some(expected),
+                "opcode 0x{:02x}",
+                val
+            );
+        }
+    }
+
+    #[test]
+    fn test_unknown_opcodes_return_none() {
+        for val in [
+            0x01, 0x02, 0x03, 0x08, 0x16, 0x19, 0x1a, 0x1b, 0x1e, 0x1f, 0x2a, 0x80, 0xff,
+        ] {
+            assert_eq!(
+                Action::from_u32(val),
+                None,
+                "expected None for 0x{:02x}",
+                val
+            );
+        }
+    }
+
+    #[test]
+    fn test_opcode_values_match_repr() {
+        // Verify the discriminant values match what from_u32 expects
+        assert_eq!(Action::End as u32, 0x00);
+        assert_eq!(Action::Push as u32, 0x96);
+        assert_eq!(Action::Add as u32, 0x0a);
+        assert_eq!(Action::If as u32, 0x9d);
+    }
+}

--- a/src/core/content_loader.rs
+++ b/src/core/content_loader.rs
@@ -106,3 +106,168 @@ impl ContentLoader {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_loader_has_no_pending() {
+        let mut loader = ContentLoader::new();
+        assert!(!loader.has_pending());
+        assert!(loader.take_pending().is_none());
+    }
+
+    #[test]
+    fn test_default_trait() {
+        let loader = ContentLoader::default();
+        assert!(!loader.has_pending());
+    }
+
+    #[test]
+    fn test_queue_load_simple_filename() {
+        let mut loader = ContentLoader::new();
+        loader.queue_load("level1.ssl");
+        assert!(loader.has_pending());
+        assert_eq!(loader.take_pending(), Some("level1.ssl".to_string()));
+    }
+
+    #[test]
+    fn test_queue_load_trims_trailing_spaces() {
+        let mut loader = ContentLoader::new();
+        loader.queue_load("BBLADE  /level1.ssl");
+        assert_eq!(loader.take_pending(), Some("BBLADE/level1.ssl".to_string()));
+    }
+
+    #[test]
+    fn test_queue_load_trims_leading_spaces() {
+        let mut loader = ContentLoader::new();
+        loader.queue_load("  BBLADE/level1.ssl");
+        assert_eq!(loader.take_pending(), Some("BBLADE/level1.ssl".to_string()));
+    }
+
+    #[test]
+    fn test_queue_load_removes_empty_segments() {
+        let mut loader = ContentLoader::new();
+        loader.queue_load("///BBLADE///level1.ssl///");
+        assert_eq!(loader.take_pending(), Some("BBLADE/level1.ssl".to_string()));
+    }
+
+    #[test]
+    fn test_queue_load_empty_string() {
+        let mut loader = ContentLoader::new();
+        loader.queue_load("");
+        assert!(!loader.has_pending(), "empty filename should not be queued");
+    }
+
+    #[test]
+    fn test_queue_load_only_spaces() {
+        let mut loader = ContentLoader::new();
+        loader.queue_load("   /   /   ");
+        assert!(
+            !loader.has_pending(),
+            "all-whitespace path should not be queued"
+        );
+    }
+
+    #[test]
+    fn test_queue_load_only_slashes() {
+        let mut loader = ContentLoader::new();
+        loader.queue_load("///");
+        assert!(!loader.has_pending(), "all-slash path should not be queued");
+    }
+
+    #[test]
+    fn test_queue_load_complex_path() {
+        let mut loader = ContentLoader::new();
+        loader.queue_load("  Game Dir  /  Sub Dir  /  file.ssl  ");
+        assert_eq!(
+            loader.take_pending(),
+            Some("Game Dir/Sub Dir/file.ssl".to_string())
+        );
+    }
+
+    #[test]
+    fn test_take_pending_consumes() {
+        let mut loader = ContentLoader::new();
+        loader.queue_load("test.ssl");
+        assert!(loader.take_pending().is_some());
+        assert!(!loader.has_pending());
+        assert!(loader.take_pending().is_none());
+    }
+
+    #[test]
+    fn test_queue_load_overwrites_previous() {
+        let mut loader = ContentLoader::new();
+        loader.queue_load("first.ssl");
+        loader.queue_load("second.ssl");
+        assert_eq!(loader.take_pending(), Some("second.ssl".to_string()));
+    }
+
+    #[test]
+    fn test_find_content_file_nonexistent() {
+        let result = ContentLoader::find_content_file(
+            std::path::Path::new("/nonexistent/game.ssl"),
+            "missing.ssl",
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_find_content_file_finds_sibling() {
+        let dir = tempfile::tempdir().unwrap();
+        let game_path = dir.path().join("game.ssl");
+        let target = dir.path().join("level2.ssl");
+        std::fs::write(&game_path, b"fake").unwrap();
+        std::fs::write(&target, b"fake").unwrap();
+
+        let result = ContentLoader::find_content_file(&game_path, "level2.ssl");
+        assert_eq!(result, Some(target));
+    }
+
+    #[test]
+    fn test_find_content_file_case_insensitive() {
+        let dir = tempfile::tempdir().unwrap();
+        let game_path = dir.path().join("game.ssl");
+        let target = dir.path().join("Level2.SSL");
+        std::fs::write(&game_path, b"fake").unwrap();
+        std::fs::write(&target, b"fake").unwrap();
+
+        let result = ContentLoader::find_content_file(&game_path, "level2.ssl");
+        // On Windows, tempfile may normalize case, so just check it was found
+        assert!(
+            result.is_some(),
+            "case-insensitive lookup should find the file"
+        );
+        assert!(result.unwrap().exists());
+    }
+
+    #[test]
+    fn test_find_content_file_in_subdirectory() {
+        let dir = tempfile::tempdir().unwrap();
+        let game_path = dir.path().join("game.ssl");
+        let sub = dir.path().join("levels");
+        std::fs::create_dir(&sub).unwrap();
+        let target = sub.join("level2.ssl");
+        std::fs::write(&game_path, b"fake").unwrap();
+        std::fs::write(&target, b"fake").unwrap();
+
+        let result = ContentLoader::find_content_file(&game_path, "levels/level2.ssl");
+        assert_eq!(result, Some(target));
+    }
+
+    #[test]
+    fn test_find_content_file_fuzzy_subdirectory() {
+        let dir = tempfile::tempdir().unwrap();
+        let game_path = dir.path().join("game.ssl");
+        let sub = dir.path().join("BBLADE");
+        std::fs::create_dir(&sub).unwrap();
+        let target = sub.join("level2.ssl");
+        std::fs::write(&game_path, b"fake").unwrap();
+        std::fs::write(&target, b"fake").unwrap();
+
+        // Query with trailing spaces (common in Native32 games)
+        let result = ContentLoader::find_content_file(&game_path, "BBLADE  /level2.ssl");
+        assert_eq!(result, Some(target));
+    }
+}

--- a/src/core/file_loader.rs
+++ b/src/core/file_loader.rs
@@ -584,3 +584,258 @@ fn endian_swap_resample(data: &[u8]) -> Vec<u8> {
     }
     result
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // === parse_resolution tests ===
+
+    #[test]
+    fn test_parse_resolution_valid() {
+        assert_eq!(parse_resolution("Resolution_320_240"), Some((320, 240)));
+        assert_eq!(parse_resolution("Resolution_640_480"), Some((640, 480)));
+        assert_eq!(parse_resolution("Resolution_1920_1080"), Some((1920, 1080)));
+    }
+
+    #[test]
+    fn test_parse_resolution_invalid_prefix() {
+        assert_eq!(parse_resolution("Garbage_320_240"), None);
+        assert_eq!(parse_resolution("resolution_320_240"), None); // case-sensitive
+    }
+
+    #[test]
+    fn test_parse_resolution_missing_parts() {
+        assert_eq!(parse_resolution("Resolution_"), None);
+        assert_eq!(parse_resolution("Resolution_320"), None);
+        assert_eq!(parse_resolution("Resolution_abc_240"), None);
+        assert_eq!(parse_resolution("Resolution_320_xyz"), None);
+    }
+
+    #[test]
+    fn test_parse_resolution_empty() {
+        assert_eq!(parse_resolution(""), None);
+    }
+
+    #[test]
+    fn test_parse_resolution_zero_dimensions() {
+        // 0 is technically valid parse, caller checks for > 0
+        assert_eq!(parse_resolution("Resolution_0_0"), Some((0, 0)));
+    }
+
+    // === endian_swap_resample tests ===
+
+    #[test]
+    fn test_endian_swap_resample_two_bytes() {
+        // 2 bytes [0x12, 0x34] → 4 bytes with endian swap
+        let input = vec![0x12, 0x34];
+        let output = endian_swap_resample(&input);
+        assert_eq!(output.len(), 4);
+        // The algorithm doubles the data and swaps bytes within each 16-bit sample
+        // Original: [0x12, 0x34] → pairs: (0x12, 0x34)
+        // Output: swap within pair → [0x34, 0x12, 0x34, 0x12]
+        assert_eq!(output, vec![0x34, 0x12, 0x34, 0x12]);
+    }
+
+    #[test]
+    fn test_endian_swap_resample_four_bytes() {
+        let input = vec![0xAA, 0xBB, 0xCC, 0xDD];
+        let output = endian_swap_resample(&input);
+        assert_eq!(output.len(), 8);
+        // Pairs: (0xAA, 0xBB), (0xCC, 0xDD)
+        // Each pair gets endian-swapped and doubled:
+        // [0xBB, 0xAA, 0xBB, 0xAA, 0xDD, 0xCC, 0xDD, 0xCC]
+        assert_eq!(output, vec![0xBB, 0xAA, 0xBB, 0xAA, 0xDD, 0xCC, 0xDD, 0xCC]);
+    }
+
+    #[test]
+    fn test_endian_swap_resample_empty() {
+        let output = endian_swap_resample(&[]);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_endian_swap_resample_odd_length() {
+        // Odd length: last byte is ignored (len & 0xFFFFFFFE)
+        let input = vec![0x12, 0x34, 0x56];
+        let output = endian_swap_resample(&input);
+        // len = 2 (0x56 ignored), result = 2 * 2 = 4 bytes
+        assert_eq!(output.len(), 4);
+        assert_eq!(output, vec![0x34, 0x12, 0x34, 0x12]);
+    }
+
+    // === ObjectType::from_u16 tests ===
+
+    #[test]
+    fn test_object_type_from_u16_valid() {
+        assert_eq!(ObjectType::from_u16(1), Some(ObjectType::Image));
+        assert_eq!(ObjectType::from_u16(2), Some(ObjectType::Movie));
+        assert_eq!(ObjectType::from_u16(3), Some(ObjectType::Button));
+        assert_eq!(ObjectType::from_u16(4), Some(ObjectType::Action));
+        assert_eq!(ObjectType::from_u16(5), Some(ObjectType::Sound));
+    }
+
+    #[test]
+    fn test_object_type_from_u16_invalid() {
+        assert_eq!(ObjectType::from_u16(0), None);
+        assert_eq!(ObjectType::from_u16(6), None);
+        assert_eq!(ObjectType::from_u16(0xFFFF), None);
+    }
+
+    // === read helper tests ===
+
+    #[test]
+    fn test_read_u16_le() {
+        let data = [0x34, 0x12, 0x78, 0x56];
+        assert_eq!(read_u16_le(&data, 0), 0x1234);
+        assert_eq!(read_u16_le(&data, 2), 0x5678);
+    }
+
+    #[test]
+    fn test_read_i16_le() {
+        let data = [0xFF, 0xFF]; // -1 in i16
+        assert_eq!(read_i16_le(&data, 0), -1);
+        let data = [0x01, 0x00]; // 1
+        assert_eq!(read_i16_le(&data, 0), 1);
+    }
+
+    #[test]
+    fn test_read_u32_le() {
+        let data = [0x78, 0x56, 0x34, 0x12];
+        assert_eq!(read_u32_le(&data, 0), 0x12345678);
+    }
+
+    // === Native32Reader basic tests ===
+
+    #[test]
+    fn test_reader_new_defaults() {
+        let reader = Native32Reader::new(vec![0u8; 100]);
+        assert_eq!(reader.colorspace, Colorspace::YUV);
+        assert_eq!(reader.resolution, (320, 240));
+        assert_eq!(reader.idx, 0);
+        assert_eq!(reader.base, 0);
+    }
+
+    #[test]
+    fn test_reader_skip_thumbnail_no_swft() {
+        let data = vec![0u8; 100];
+        let mut reader = Native32Reader::new(data);
+        reader.skip_thumbnail();
+        assert_eq!(reader.idx, 0); // no SWFT header, idx unchanged
+    }
+
+    #[test]
+    fn test_reader_skip_thumbnail_with_swft() {
+        let mut data = vec![0u8; 256];
+        // Write "SWFT" magic
+        data[0..4].copy_from_slice(b"SWFT");
+        // Thumbnail size at offset 0x0c (relative to idx+4): 16 bytes
+        data[0x10..0x14].copy_from_slice(&16u32.to_le_bytes());
+
+        let mut reader = Native32Reader::new(data);
+        reader.skip_thumbnail();
+        // Should skip: 4 (SWFT) + 0x10 (header) + 16 (size) = 36
+        assert_eq!(reader.idx, 36);
+    }
+
+    #[test]
+    fn test_reader_find_header_yuv() {
+        let mut data = vec![0u8; 256];
+        data[10..14].copy_from_slice(b"_YUV");
+        let mut reader = Native32Reader::new(data);
+        reader.idx = 10;
+        assert!(reader.find_header().is_ok());
+        assert_eq!(reader.colorspace, Colorspace::YUV);
+    }
+
+    #[test]
+    fn test_reader_find_header_argb() {
+        let mut data = vec![0u8; 256];
+        data[20..24].copy_from_slice(b"ARGB");
+        let mut reader = Native32Reader::new(data);
+        reader.idx = 20;
+        assert!(reader.find_header().is_ok());
+        assert_eq!(reader.colorspace, Colorspace::ARGB);
+    }
+
+    #[test]
+    fn test_reader_find_header_not_found() {
+        let data = vec![0u8; 64];
+        let mut reader = Native32Reader::new(data);
+        let result = reader.find_header();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_reader_get_str() {
+        let data = b"hello\0world".to_vec();
+        let reader = Native32Reader::new(data);
+        assert_eq!(reader.get_str(0), "hello");
+        assert_eq!(reader.get_str(6), "world");
+    }
+
+    #[test]
+    fn test_reader_get_str_at_end_of_data() {
+        let data = b"test".to_vec();
+        let reader = Native32Reader::new(data);
+        assert_eq!(reader.get_str(0), "test");
+    }
+
+    #[test]
+    fn test_frame_object_debug() {
+        let obj = FrameObject {
+            obj_type: ObjectType::Image,
+            index: 5,
+            x: 10,
+            y: 20,
+            depth: 0,
+            name: Some("test".to_string()),
+        };
+        let debug = format!("{:?}", obj);
+        assert!(debug.contains("Image"));
+        assert!(debug.contains("test"));
+    }
+
+    #[test]
+    fn test_movie_frame_copy() {
+        let mf = MovieFrame {
+            image: 1,
+            x: 10,
+            y: 20,
+            action: 0,
+            sound: 0,
+            reserved: 0,
+        };
+        let mf2 = mf; // Copy
+        assert_eq!(mf2.image, 1);
+        assert_eq!(mf2.x, 10);
+    }
+
+    #[test]
+    fn test_colorspace_equality() {
+        assert_eq!(Colorspace::YUV, Colorspace::YUV);
+        assert_eq!(Colorspace::ARGB, Colorspace::ARGB);
+        assert_ne!(Colorspace::YUV, Colorspace::ARGB);
+    }
+
+    #[test]
+    fn test_audio_format_equality() {
+        assert_eq!(AudioFormat::MP3, AudioFormat::MP3);
+        assert_eq!(AudioFormat::Raw, AudioFormat::Raw);
+        assert_ne!(AudioFormat::MP3, AudioFormat::Raw);
+    }
+
+    #[test]
+    fn test_action_payload_variants() {
+        let s = ActionPayload::String("hello".to_string());
+        let i = ActionPayload::Integer(42);
+        match s {
+            ActionPayload::String(v) => assert_eq!(v, "hello"),
+            _ => panic!("expected String"),
+        }
+        match i {
+            ActionPayload::Integer(v) => assert_eq!(v, 42),
+            _ => panic!("expected Integer"),
+        }
+    }
+}

--- a/src/core/frame_player.rs
+++ b/src/core/frame_player.rs
@@ -45,3 +45,109 @@ impl FramePlayer {
         self.playing = playing;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_initial_state() {
+        let fp = FramePlayer::new();
+        assert_eq!(fp.current_frame, 0);
+        assert!(fp.playing);
+        assert_eq!(fp.next_frame, Some(1));
+    }
+
+    #[test]
+    fn test_default_trait() {
+        let fp = FramePlayer::default();
+        assert_eq!(fp.current_frame, 0);
+        assert!(fp.playing);
+    }
+
+    #[test]
+    fn test_take_next_frame_consumes() {
+        let mut fp = FramePlayer::new();
+        assert_eq!(fp.take_next_frame(), Some(1));
+        assert!(fp.next_frame.is_none());
+    }
+
+    #[test]
+    fn test_take_next_frame_returns_none_when_empty() {
+        let mut fp = FramePlayer::new();
+        fp.take_next_frame();
+        assert_eq!(fp.take_next_frame(), None);
+    }
+
+    #[test]
+    fn test_has_pending_frame() {
+        let mut fp = FramePlayer::new();
+        assert!(fp.has_pending_frame());
+        fp.take_next_frame();
+        assert!(!fp.has_pending_frame());
+    }
+
+    #[test]
+    fn test_tick_advances_when_playing_and_no_pending() {
+        let mut fp = FramePlayer::new();
+        fp.current_frame = 5;
+        fp.take_next_frame(); // consume initial Some(1)
+        fp.tick();
+        assert_eq!(fp.next_frame, Some(6)); // current_frame + 1
+    }
+
+    #[test]
+    fn test_tick_does_not_advance_when_paused() {
+        let mut fp = FramePlayer::new();
+        fp.playing = false;
+        fp.take_next_frame(); // consume initial Some(1)
+        fp.tick();
+        assert!(fp.next_frame.is_none());
+    }
+
+    #[test]
+    fn test_tick_does_not_advance_when_pending_exists() {
+        let mut fp = FramePlayer::new();
+        // next_frame is Some(1) initially
+        fp.tick();
+        // Should still be Some(1), not overwritten
+        assert_eq!(fp.next_frame, Some(1));
+    }
+
+    #[test]
+    fn test_goto_sets_frame_and_playing() {
+        let mut fp = FramePlayer::new();
+        fp.goto(42, false);
+        assert_eq!(fp.next_frame, Some(42));
+        assert!(!fp.playing);
+
+        fp.goto(100, true);
+        assert_eq!(fp.next_frame, Some(100));
+        assert!(fp.playing);
+    }
+
+    #[test]
+    fn test_goto_frame_zero() {
+        let mut fp = FramePlayer::new();
+        fp.goto(0, true);
+        assert_eq!(fp.next_frame, Some(0));
+    }
+
+    #[test]
+    fn test_full_tick_cycle() {
+        let mut fp = FramePlayer::new();
+        // Initial: frame 0, next=Some(1)
+        assert_eq!(fp.current_frame, 0);
+
+        // Take the pending frame
+        let next = fp.take_next_frame();
+        assert_eq!(next, Some(1));
+
+        // Simulate emulator setting current_frame
+        fp.current_frame = 1;
+
+        // Tick should advance to 2
+        fp.tick();
+        assert_eq!(fp.next_frame, Some(2));
+    }
+}

--- a/src/core/header_decryptor.rs
+++ b/src/core/header_decryptor.rs
@@ -2,7 +2,10 @@
 // This is NOT a standard DES implementation - it uses the same algorithm
 // as the reference implementation to ensure compatibility.
 
-use crate::core::des_constants::*;
+use crate::core::des_constants::{
+    DES_SBOXES, FINAL_MESSAGE_PERMUTATION, INITIAL_KEY_PERMUTATION, INITIAL_MESSAGE_PERMUTATION,
+    KEY_SHIFT_SIZES, MESSAGE_SHUFFLE, RIGHT_SUB_MESSAGE_PERMUTATION, SUB_KEY_PERMUTATION,
+};
 
 fn expand_bits(data: &[u8], count: usize) -> Vec<u8> {
     let mut result = vec![0u8; count];

--- a/src/core/image_decoder.rs
+++ b/src/core/image_decoder.rs
@@ -263,3 +263,263 @@ fn argb1555_to_argb(value: u16) -> u32 {
 fn read_u16_le(data: &[u8], offset: usize) -> u16 {
     u16::from_le_bytes([data[offset], data[offset + 1]])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // === clip() tests ===
+
+    #[test]
+    fn test_clip_normal_values() {
+        assert_eq!(clip(0), 0);
+        assert_eq!(clip(128), 128);
+        assert_eq!(clip(255), 255);
+    }
+
+    #[test]
+    fn test_clip_clamps_low() {
+        assert_eq!(clip(-1), 0);
+        assert_eq!(clip(-1000), 0);
+    }
+
+    #[test]
+    fn test_clip_clamps_high() {
+        assert_eq!(clip(256), 255);
+        assert_eq!(clip(1000), 255);
+    }
+
+    // === argb1555_to_argb() tests ===
+
+    #[test]
+    fn test_argb1555_transparent() {
+        // bit 15 = 0 → transparent
+        assert_eq!(argb1555_to_argb(0x0000), 0x00000000);
+        assert_eq!(argb1555_to_argb(0x7FFF), 0x00000000); // bit 15 still 0
+    }
+
+    #[test]
+    fn test_argb1555_white() {
+        // bit 15 = 1, R=31, G=31, B=31
+        // 5-bit max 31 → shifted left by 3 → 248 (0xF8), not 255
+        assert_eq!(argb1555_to_argb(0xFFFF), 0xFFF8F8F8);
+    }
+
+    #[test]
+    fn test_argb1555_red() {
+        // bit 15 = 1, R=31, G=0, B=0
+        // value = 0x8000 | 31 = 0x801F
+        let result = argb1555_to_argb(0x801F);
+        assert_eq!(result & 0xFF000000, 0xFF000000); // alpha = 0xFF
+        assert_eq!((result >> 16) & 0xFF, 0xF8); // R = 31 << 3 = 248
+        assert_eq!((result >> 8) & 0xFF, 0x00); // G = 0
+        assert_eq!(result & 0xFF, 0x00); // B = 0
+    }
+
+    #[test]
+    fn test_argb1555_green() {
+        // bit 15 = 1, R=0, G=31, B=0
+        // value = 0x8000 | (31 << 5) = 0x83E0
+        let result = argb1555_to_argb(0x83E0);
+        assert_eq!((result >> 16) & 0xFF, 0x00); // R = 0
+        assert_eq!((result >> 8) & 0xFF, 0xF8); // G = 31 << 3 = 248
+        assert_eq!(result & 0xFF, 0x00); // B = 0
+    }
+
+    #[test]
+    fn test_argb1555_blue() {
+        // bit 15 = 1, R=0, G=0, B=31
+        // value = 0x8000 | (31 << 10) = 0x8000 | 0x7C00 = 0xFC00
+        let result = argb1555_to_argb(0xFC00);
+        assert_eq!((result >> 16) & 0xFF, 0x00); // R = 0
+        assert_eq!((result >> 8) & 0xFF, 0x00); // G = 0
+        assert_eq!(result & 0xFF, 0xF8); // B = 31 << 3 = 248
+    }
+
+    // === RgbaImage tests ===
+
+    #[test]
+    fn test_rgba_image_clone() {
+        let img = RgbaImage {
+            width: 2,
+            height: 1,
+            pixels: vec![0xFF000000, 0x00FF0000],
+        };
+        let img2 = img.clone();
+        assert_eq!(img2.width, 2);
+        assert_eq!(img2.pixels, vec![0xFF000000, 0x00FF0000]);
+    }
+
+    // === decode_image_yuv tests ===
+
+    #[test]
+    fn test_decode_yuv_empty_data() {
+        assert!(decode_image_yuv(&[]).is_none());
+    }
+
+    #[test]
+    fn test_decode_yuv_too_short() {
+        // Less than 8 bytes header
+        assert!(decode_image_yuv(&[0u8; 7]).is_none());
+    }
+
+    #[test]
+    fn test_decode_yuv_zero_dimensions() {
+        let mut data = vec![0u8; 16];
+        // width = 0
+        data[0..2].copy_from_slice(&0u16.to_le_bytes());
+        data[2..4].copy_from_slice(&240u16.to_le_bytes());
+        assert!(decode_image_yuv(&data).is_none());
+    }
+
+    #[test]
+    fn test_decode_yuv_minimal_image() {
+        // 2x2 YUV image (minimum valid: uv_w=1, uv_h=1)
+        let mut data = vec![0u8; 64];
+        data[0..2].copy_from_slice(&2u16.to_le_bytes()); // width=2
+        data[2..4].copy_from_slice(&2u16.to_le_bytes()); // height=2
+                                                         // img_size = enough for 1 pixel quad (6 bytes) + header offset
+        data[4..8].copy_from_slice(&12u32.to_le_bytes());
+
+        // Command: literal 1 quad (0x8000 | 1 = 0x8001)
+        data[8..10].copy_from_slice(&0x8001u16.to_le_bytes());
+        // 6 bytes of YUV data: Y0, Y1, Y2, Y3, V, U
+        data[10] = 128; // Y0
+        data[11] = 128; // Y1
+        data[12] = 128; // Y2
+        data[13] = 128; // Y3
+        data[14] = 128; // V
+        data[15] = 128; // U
+
+        let result = decode_image_yuv(&data);
+        assert!(result.is_some());
+        let img = result.unwrap();
+        assert_eq!(img.width, 2);
+        assert_eq!(img.height, 2);
+        assert_eq!(img.pixels.len(), 4);
+    }
+
+    // === decode_image_argb tests ===
+
+    #[test]
+    fn test_decode_argb_empty_data() {
+        assert!(decode_image_argb(&[]).is_none());
+    }
+
+    #[test]
+    fn test_decode_argb_too_short() {
+        assert!(decode_image_argb(&[0u8; 7]).is_none());
+    }
+
+    #[test]
+    fn test_decode_argb_zero_dimensions() {
+        let mut data = vec![0u8; 16];
+        data[0..2].copy_from_slice(&0u16.to_le_bytes()); // width=0
+        data[2..4].copy_from_slice(&2u16.to_le_bytes()); // height=2
+        assert!(decode_image_argb(&data).is_none());
+    }
+
+    #[test]
+    fn test_decode_argb_transparent_pixel() {
+        let mut data = vec![0u8; 32];
+        data[0..2].copy_from_slice(&1u16.to_le_bytes()); // width=1
+        data[2..4].copy_from_slice(&1u16.to_le_bytes()); // height=1
+        data[4..8].copy_from_slice(&2u32.to_le_bytes()); // img_size=2 (1 command)
+
+        // Command: 0x0000 = literal transparent pixel
+        data[8..10].copy_from_slice(&0x0000u16.to_le_bytes());
+
+        let result = decode_image_argb(&data);
+        assert!(result.is_some());
+        let img = result.unwrap();
+        assert_eq!(img.pixels[0], 0x00000000); // transparent
+    }
+
+    #[test]
+    fn test_decode_argb_repeated_pixel() {
+        let mut data = vec![0u8; 32];
+        data[0..2].copy_from_slice(&3u16.to_le_bytes()); // width=3
+        data[2..4].copy_from_slice(&1u16.to_le_bytes()); // height=1
+        data[4..8].copy_from_slice(&4u32.to_le_bytes()); // img_size=4 (1 command + 1 pixel)
+
+        // Command: 0xC000 | 3 = repeat 3 times
+        data[8..10].copy_from_slice(&(0xC000u16 | 3).to_le_bytes());
+        // ARGB1555 value: white (0xFFFF) → ARGB8888 = 0xFFF8F8F8 (5-bit max 31→248)
+        data[10..12].copy_from_slice(&0xFFFFu16.to_le_bytes());
+
+        let result = decode_image_argb(&data);
+        assert!(result.is_some());
+        let img = result.unwrap();
+        assert_eq!(img.pixels.len(), 3);
+        for pixel in &img.pixels {
+            assert_eq!(*pixel, 0xFFF8F8F8); // white: 5-bit 31<<3=248 per channel
+        }
+    }
+
+    #[test]
+    fn test_decode_argb_unknown_command_returns_none() {
+        let mut data = vec![0u8; 32];
+        data[0..2].copy_from_slice(&1u16.to_le_bytes()); // width=1
+        data[2..4].copy_from_slice(&1u16.to_le_bytes()); // height=1
+        data[4..8].copy_from_slice(&2u32.to_le_bytes()); // img_size=2
+
+        // Unknown command: 0x4000 (not 0x0000 and not 0xC000 prefix)
+        data[8..10].copy_from_slice(&0x4000u16.to_le_bytes());
+
+        let result = decode_image_argb(&data);
+        assert!(result.is_none());
+    }
+
+    // === interpolate_y tests ===
+
+    #[test]
+    fn test_interpolate_y_identity_for_uniform() {
+        // Uniform non-zero data should pass through
+        let data = vec![128u8; 4]; // 2x2
+        let result = interpolate_y(&data, 2, 2);
+        assert_eq!(result.len(), 8); // 2x4
+                                     // All values should be 128
+        for v in &result {
+            assert_eq!(*v, 128);
+        }
+    }
+
+    #[test]
+    fn test_interpolate_y_doubles_height() {
+        let data = vec![10u8; 6]; // 3x2
+        let result = interpolate_y(&data, 3, 2);
+        assert_eq!(result.len(), 12); // 3x4
+    }
+
+    // === interpolate_x tests ===
+
+    #[test]
+    fn test_interpolate_x_identity_for_uniform() {
+        let data = vec![128u8; 4]; // 2x2
+        let result = interpolate_x(&data, 2, 2);
+        assert_eq!(result.len(), 8); // 4x2
+        for v in &result {
+            assert_eq!(*v, 128);
+        }
+    }
+
+    #[test]
+    fn test_interpolate_x_doubles_width() {
+        let data = vec![10u8; 6]; // 3x2
+        let result = interpolate_x(&data, 3, 2);
+        assert_eq!(result.len(), 12); // 6x2
+    }
+
+    // === read_u16_le_slice tests ===
+
+    #[test]
+    fn test_read_u16_le_slice() {
+        assert_eq!(read_u16_le_slice(&[0x34, 0x12], 0), 0x1234);
+        assert_eq!(read_u16_le_slice(&[0x00, 0x34, 0x12, 0x00], 1), 0x1234);
+    }
+
+    #[test]
+    fn test_read_u32_le_slice() {
+        assert_eq!(read_u32_le_slice(&[0x78, 0x56, 0x34, 0x12], 0), 0x12345678);
+    }
+}

--- a/src/core/input_handler.rs
+++ b/src/core/input_handler.rs
@@ -82,3 +82,64 @@ impl InputHandler {
         self.pressed_buttons.iter().copied().collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_handler_has_no_pressed_buttons() {
+        let handler = InputHandler::new();
+        assert!(handler.get_pressed_buttons().is_empty());
+    }
+
+    #[test]
+    fn test_default_trait() {
+        let handler = InputHandler::default();
+        assert!(handler.get_pressed_buttons().is_empty());
+    }
+
+    #[test]
+    fn test_set_buttons_stores_keycodes() {
+        let mut handler = InputHandler::new();
+        handler.set_buttons(&[0x0200, 0x1c00]); // Left, Up
+        let pressed = handler.get_pressed_buttons();
+        assert_eq!(pressed.len(), 2);
+        assert!(pressed.contains(&0x0200));
+        assert!(pressed.contains(&0x1c00));
+    }
+
+    #[test]
+    fn test_set_buttons_clears_previous() {
+        let mut handler = InputHandler::new();
+        handler.set_buttons(&[0x0200]);
+        handler.set_buttons(&[0x0400]); // replace with Right only
+        let pressed = handler.get_pressed_buttons();
+        assert_eq!(pressed.len(), 1);
+        assert!(pressed.contains(&0x0400));
+        assert!(!pressed.contains(&0x0200));
+    }
+
+    #[test]
+    fn test_set_buttons_empty_clears_all() {
+        let mut handler = InputHandler::new();
+        handler.set_buttons(&[0x0200, 0x0400]);
+        handler.set_buttons(&[]);
+        assert!(handler.get_pressed_buttons().is_empty());
+    }
+
+    #[test]
+    fn test_set_buttons_deduplicates() {
+        let mut handler = InputHandler::new();
+        handler.set_buttons(&[0x0200, 0x0200, 0x0200]);
+        let pressed = handler.get_pressed_buttons();
+        assert_eq!(pressed.len(), 1);
+    }
+
+    #[test]
+    fn test_set_buttons_with_all_directions() {
+        let mut handler = InputHandler::new();
+        handler.set_buttons(&[0x0200, 0x0400, 0x1c00, 0x1e00, 0x4000, 0x8800]);
+        assert_eq!(handler.get_pressed_buttons().len(), 6);
+    }
+}

--- a/src/core/save_manager.rs
+++ b/src/core/save_manager.rs
@@ -45,3 +45,80 @@ impl SaveManager {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_save_path_has_ssl_sav_suffix() {
+        let game_path = Path::new("/some/path/game.ssl");
+        let sm = SaveManager::new(game_path);
+        assert_eq!(sm.save_path, PathBuf::from("/some/path/game.ssl.ssl_sav"));
+    }
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let game_path = dir.path().join("test_game.ssl");
+        std::fs::write(&game_path, b"fake game data").unwrap();
+
+        let sm = SaveManager::new(&game_path);
+        let test_data = "highscore=9999;level=5";
+
+        assert!(sm.save(test_data));
+        let loaded = sm.load();
+        assert_eq!(loaded, Some(test_data.to_string()));
+    }
+
+    #[test]
+    fn test_load_nonexistent_returns_none() {
+        let sm = SaveManager::new(Path::new("/nonexistent/path/game.ssl"));
+        assert!(sm.load().is_none());
+    }
+
+    #[test]
+    fn test_save_overwrites_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let game_path = dir.path().join("test_game.ssl");
+        std::fs::write(&game_path, b"fake").unwrap();
+
+        let sm = SaveManager::new(&game_path);
+        assert!(sm.save("first"));
+        assert!(sm.save("second"));
+        assert_eq!(sm.load(), Some("second".to_string()));
+    }
+
+    #[test]
+    fn test_save_returns_true_on_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let game_path = dir.path().join("test_game.ssl");
+        std::fs::write(&game_path, b"fake").unwrap();
+
+        let sm = SaveManager::new(&game_path);
+        assert!(sm.save("data"));
+    }
+
+    #[test]
+    fn test_load_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let game_path = dir.path().join("test_game.ssl");
+        std::fs::write(&game_path, b"fake").unwrap();
+
+        let sm = SaveManager::new(&game_path);
+        sm.save("");
+        assert_eq!(sm.load(), Some("".to_string()));
+    }
+
+    #[test]
+    fn test_save_unicode_data() {
+        let dir = tempfile::tempdir().unwrap();
+        let game_path = dir.path().join("test_game.ssl");
+        std::fs::write(&game_path, b"fake").unwrap();
+
+        let sm = SaveManager::new(&game_path);
+        let data = "name=测试玩家;score=100";
+        assert!(sm.save(data));
+        assert_eq!(sm.load(), Some(data.to_string()));
+    }
+}

--- a/src/core/sprite_system.rs
+++ b/src/core/sprite_system.rs
@@ -132,3 +132,231 @@ impl SpriteSystem {
         self.sprites.contains_key(name)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::file_loader::{FrameObject, ObjectType};
+
+    fn make_movie_object(name: &str, index: u16, x: i16, y: i16, depth: u16) -> FrameObject {
+        FrameObject {
+            obj_type: ObjectType::Movie,
+            index,
+            x,
+            y,
+            depth,
+            name: Some(name.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_new_system_is_empty() {
+        let ss = SpriteSystem::new();
+        assert_eq!(ss.sprites.len(), 0);
+    }
+
+    #[test]
+    fn test_default_trait() {
+        let ss = SpriteSystem::default();
+        assert_eq!(ss.sprites.len(), 0);
+    }
+
+    #[test]
+    fn test_insert_and_get() {
+        let mut ss = SpriteSystem::new();
+        let state = MovieState::new(1, 10, 20, 5);
+        ss.insert("hero".to_string(), state);
+
+        let movie = ss.get("hero").unwrap();
+        assert_eq!(movie.movie, 1);
+        assert_eq!(movie.x, 10);
+        assert_eq!(movie.y, 20);
+        assert_eq!(movie.depth, 5);
+    }
+
+    #[test]
+    fn test_get_nonexistent_returns_none() {
+        let ss = SpriteSystem::new();
+        assert!(ss.get("missing").is_none());
+    }
+
+    #[test]
+    fn test_contains_key() {
+        let mut ss = SpriteSystem::new();
+        assert!(!ss.contains_key("a"));
+        ss.insert("a".to_string(), MovieState::new(1, 0, 0, 0));
+        assert!(ss.contains_key("a"));
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut ss = SpriteSystem::new();
+        ss.insert("a".to_string(), MovieState::new(1, 0, 0, 0));
+        let removed = ss.remove("a");
+        assert!(removed.is_some());
+        assert_eq!(removed.unwrap().movie, 1);
+        assert!(!ss.contains_key("a"));
+    }
+
+    #[test]
+    fn test_remove_nonexistent_returns_none() {
+        let mut ss = SpriteSystem::new();
+        assert!(ss.remove("missing").is_none());
+    }
+
+    #[test]
+    fn test_update_for_frame_adds_new_movies() {
+        let mut ss = SpriteSystem::new();
+        let objects = vec![make_movie_object("hero", 1, 10, 20, 0)];
+        ss.update_for_frame(&objects);
+
+        assert!(ss.contains_key("hero"));
+        let movie = ss.get("hero").unwrap();
+        assert_eq!(movie.movie, 1);
+        assert_eq!(movie.x, 10);
+        assert_eq!(movie.y, 20);
+        assert!(movie.visible);
+        assert!(movie.playing);
+        assert!(!movie.cloned);
+        assert_eq!(movie.next_frame, Some(0));
+    }
+
+    #[test]
+    fn test_update_for_frame_preserves_existing_state() {
+        let mut ss = SpriteSystem::new();
+        let mut state = MovieState::new(1, 0, 0, 0);
+        state.frame = 42;
+        state.visible = false;
+        ss.insert("hero".to_string(), state);
+
+        // Same movie in new frame
+        let objects = vec![make_movie_object("hero", 1, 10, 20, 0)];
+        ss.update_for_frame(&objects);
+
+        let movie = ss.get("hero").unwrap();
+        assert_eq!(movie.frame, 42, "frame should be preserved");
+        assert!(!movie.visible, "visibility should be preserved");
+    }
+
+    #[test]
+    fn test_update_for_frame_removes_non_cloned_absent_movies() {
+        let mut ss = SpriteSystem::new();
+        ss.insert("old".to_string(), MovieState::new(1, 0, 0, 0));
+
+        // Empty frame - "old" should be removed
+        ss.update_for_frame(&[]);
+        assert!(!ss.contains_key("old"));
+    }
+
+    #[test]
+    fn test_update_for_frame_keeps_cloned_movies() {
+        let mut ss = SpriteSystem::new();
+        let mut state = MovieState::new(1, 0, 0, 0);
+        state.cloned = true;
+        ss.insert("clone".to_string(), state);
+
+        ss.update_for_frame(&[]);
+        assert!(ss.contains_key("clone"), "cloned movie should survive");
+    }
+
+    #[test]
+    fn test_update_for_frame_ignores_non_movie_objects() {
+        let mut ss = SpriteSystem::new();
+        let objects = vec![FrameObject {
+            obj_type: ObjectType::Image,
+            index: 1,
+            x: 0,
+            y: 0,
+            depth: 0,
+            name: Some("not_a_movie".to_string()),
+        }];
+        ss.update_for_frame(&objects);
+        assert!(!ss.contains_key("not_a_movie"));
+    }
+
+    #[test]
+    fn test_update_for_frame_multiple_movies() {
+        let mut ss = SpriteSystem::new();
+        let objects = vec![
+            make_movie_object("a", 1, 0, 0, 0),
+            make_movie_object("b", 2, 10, 20, 1),
+            make_movie_object("c", 3, 30, 40, 2),
+        ];
+        ss.update_for_frame(&objects);
+        assert_eq!(ss.sprites.len(), 3);
+    }
+
+    #[test]
+    fn test_movie_state_new_defaults() {
+        let ms = MovieState::new(5, 100, 200, 10);
+        assert_eq!(ms.movie, 5);
+        assert_eq!(ms.x, 100);
+        assert_eq!(ms.y, 200);
+        assert_eq!(ms.depth, 10);
+        assert_eq!(ms.frame, 0);
+        assert!(ms.visible);
+        assert!(ms.playing);
+        assert!(!ms.cloned);
+        assert!(ms.sound_channel.is_none());
+        assert_eq!(ms.next_frame, Some(0));
+    }
+
+    #[test]
+    fn test_iter_and_iter_mut() {
+        let mut ss = SpriteSystem::new();
+        ss.insert("a".to_string(), MovieState::new(1, 0, 0, 0));
+        ss.insert("b".to_string(), MovieState::new(2, 0, 0, 0));
+
+        let names: Vec<&String> = ss.iter().map(|(name, _)| name).collect();
+        assert_eq!(names.len(), 2);
+        assert!(names.contains(&&"a".to_string()));
+        assert!(names.contains(&&"b".to_string()));
+
+        // Mutate via iter_mut
+        for (_, movie) in ss.iter_mut() {
+            movie.frame = 99;
+        }
+        assert_eq!(ss.get("a").unwrap().frame, 99);
+        assert_eq!(ss.get("b").unwrap().frame, 99);
+    }
+
+    #[test]
+    fn test_get_mut() {
+        let mut ss = SpriteSystem::new();
+        ss.insert("hero".to_string(), MovieState::new(1, 0, 0, 0));
+
+        if let Some(movie) = ss.get_mut("hero") {
+            movie.x = 42;
+            movie.y = 84;
+        }
+        assert_eq!(ss.get("hero").unwrap().x, 42);
+        assert_eq!(ss.get("hero").unwrap().y, 84);
+    }
+
+    #[test]
+    fn test_update_removes_old_and_adds_new() {
+        let mut ss = SpriteSystem::new();
+        ss.insert("old".to_string(), MovieState::new(1, 0, 0, 0));
+
+        let objects = vec![make_movie_object("new", 2, 0, 0, 0)];
+        ss.update_for_frame(&objects);
+
+        assert!(!ss.contains_key("old"));
+        assert!(ss.contains_key("new"));
+    }
+
+    #[test]
+    fn test_movie_without_name_is_skipped() {
+        let mut ss = SpriteSystem::new();
+        let objects = vec![FrameObject {
+            obj_type: ObjectType::Movie,
+            index: 1,
+            x: 0,
+            y: 0,
+            depth: 0,
+            name: None, // no name
+        }];
+        ss.update_for_frame(&objects);
+        assert_eq!(ss.sprites.len(), 0);
+    }
+}


### PR DESCRIPTION
## Background

The project had zero test coverage. Changes to one module frequently broke other modules ("改 A 影响了 B") with no automated way to detect regressions.

After researching the libretro ecosystem (mgba, flycast, bsnes, mupen64plus, stella), we found that **virtually no emulator core has unit tests** — only the RetroArch frontend and libretro-common shared library have meaningful test infrastructure. This PR establishes a test foundation specific to this project.

## Test Strategy

Tests are organized in three tiers:

### Tier 1 — Pure Function Unit Tests (zero dependencies)

Tests for stateless helper functions that can be verified in isolation:

- **`actions.rs`** — `from_u32()` opcode mapping for all 46 known opcodes, unknown opcode rejection, discriminant value consistency
- **`action_vm.rs`** — `str_to_float()`, `str_to_int()`, `to_string()`, `ActionProp::from_u32()`
- **`file_loader.rs`** — `parse_resolution()`, `endian_swap_resample()`, `ObjectType::from_u16()`, `read_u16_le`/`read_i16_le`/`read_u32_le` helpers
- **`image_decoder.rs`** — `clip()` clamping, `argb1555_to_argb()` color conversion, YUV/ARGB decode (empty/short/zero-dimension inputs, minimal valid images), `interpolate_y()`/`interpolate_x()` upsampling

### Tier 2 — Component Unit Tests (mock dependencies)

Tests for stateful components using mock objects:

- **`action_vm.rs`** (60 tests) — Full VM opcode coverage using a `MockVmHost` and programmatically constructed `Native32Reader`:
  - Arithmetic: Add, Subtract, Multiply, Divide (including divide-by-zero)
  - Comparison: Equals, Less
  - Logic: And, Or, Not
  - String: StringEquals, StringAdd, StringLength, StringExtract, StringLess
  - Type conversion: ToInteger, CharToAscii, AsciiToChar
  - Variable: SetVariable, GetVariable (including undefined variables)
  - Control flow: If (true/false branches), Jump
  - Host interaction: Stop, Play, StopSounds, NextFrame, PreviousFrame, GotoFrame, GotoFrame2, CloneSprite, RemoveSprite, GetTime, RandomNumber
  - Edge cases: empty program, pop empty stack, set variable on empty stack
  - Complex sequences: arithmetic chains `(3+5)*2=16`, conditional logic `if(3<5)`

- **`frame_player.rs`** (11 tests) — State machine: initial state, tick advancement, pause/play, goto, frame consumption
- **`sprite_system.rs`** (15 tests) — CRUD operations, `update_for_frame()` (add new movies, preserve existing state, remove absent non-cloned, keep cloned), iteration
- **`input_handler.rs`** (7 tests) — Button state storage, clearing, deduplication
- **`content_loader.rs`** (15 tests) — Path parsing (trailing spaces, leading spaces, empty segments, all-whitespace), file lookup (sibling, case-insensitive, subdirectory, fuzzy matching with trailing spaces)
- **`save_manager.rs`** (7 tests) — Save/load roundtrip, overwrite, empty file, unicode data

### Tier 3 — Integration Tests (future)

Not included in this PR. Would require test game files (Native32 `.ssl` format) to test `Emulator::from_path()` → `tick()` → `draw()` end-to-end.

## Coverage Summary

| Module | Tests | What's Covered |
|--------|-------|---------------|
| `actions.rs` | 3 | All opcode mappings |
| `action_vm.rs` | 60 | All 30+ VM opcodes, edge cases, complex sequences |
| `file_loader.rs` | 20 | Binary parsing, resolution, endianness, reader basics |
| `image_decoder.rs` | 22 | Both decoders, pixel conversion, interpolation |
| `frame_player.rs` | 11 | Complete state machine |
| `sprite_system.rs` | 15 | Complete CRUD + frame update logic |
| `input_handler.rs` | 7 | Complete button state management |
| `content_loader.rs` | 15 | Path parsing + filesystem lookup |
| `save_manager.rs` | 7 | Complete save/load lifecycle |
| **Total** | **175** | |

## CI & SonarCloud Integration

- Added `sonar.rust.cobertura.reportPaths=coverage/cobertura.xml` to `sonar-project.properties` so SonarCloud receives test coverage data from `cargo-tarpaulin`
- SonarCloud now natively supports Rust with Cobertura and LCOV coverage formats ([announcement](https://community.sonarsource.com/t/sonarqube-now-supports-rust/138933))
- Coverage is generated by the existing `sonar-report.yml` workflow via `cargo tarpaulin --out xml`

## Technical Notes

- `ActionProp` gains `Hash` derive (required for use as `HashMap` key in `MockHost`)
- `tempfile` added to `[dev-dependencies]` for filesystem-dependent tests in `content_loader` and `save_manager`
- VM tests use `make_test_reader()` helper to construct minimal `Native32Reader` instances with pre-loaded bytecode, avoiding the need for real game files
- All tests run in < 0.02s total — no performance impact on CI

## What This Prevents

With these tests in place, the following regression scenarios will be caught automatically:

1. Changing an ActionScript opcode handler breaks arithmetic/logic/string operations
2. Modifying `Native32Reader` parsing corrupts frame/movie/action loading
3. Image decoder changes produce wrong pixel values
4. Sprite system refactor breaks movie lifecycle (add/remove/clone)
5. Content loader path normalization changes break game file discovery
6. Frame player state machine gets stuck or skips frames