### PR TITLE
fix(core): stop re-running movie keyframe actions on main timeline switch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,3 +14,76 @@ Examples of changes that require doc updates:
 - Audio/video feature changes
 - RetroArch core behavior changes
 - New dependencies or build requirement changes
+
+## Debugging Runtime / Interaction Bugs
+
+Use this playbook for "the game does X wrong at runtime" reports, especially
+input-driven ones like "pressing a key freezes the screen". The emulator core
+(`crates/native32emu-core`) is platform-independent and can be driven headlessly,
+which is the key to fast, deterministic debugging.
+
+### 1. Reproduce headlessly with scripted input
+
+Don't debug through the window. Drive the core directly and script input per
+frame. The Action VM is seeded deterministically, so a fixed input script always
+produces the same run.
+
+Reusable harness lives in `crates/native32emu-core/tests/smoke.rs`:
+
+- `run_scripted(path, frames, |frame| -> Vec<u16>)` — drives the core with a
+  per-frame input script and returns the final `Emulator` for inspection.
+- `find_asset(dir, "GFSTART.SSL")` — locates a game asset by name.
+- Native32 keycodes (see `input_handler.rs`): Left `0x0200`, Right `0x0400`,
+  Up `0x1c00`, Down `0x1e00`, Z/A `0x4000`, X/B `0x8800`.
+
+A throwaway `examples/` binary that prints per-frame state is fine for live
+investigation; delete it once the regression test is written.
+
+### 2. Quantify the symptom, then narrow from coarse to fine
+
+Turn "looks stuck" into a number, then drill down layer by layer:
+
+1. Main timeline: `emu.frame_player.current_frame` / `.playing`.
+2. Script state: relevant `emu.vm.vars` entries (names are lowercased).
+3. Sprites/movies: `emu.sprites.get("name")` → `.frame` / `.playing` / `.next_frame`.
+
+Pin down the exact object that is misbehaving (e.g. "movie X is stuck on frame N
+with playing=false") before reading any code.
+
+### 3. Add gated tracing, not permanent logging
+
+For a hard case, add temporary `eprintln!` guarded by an env var so it is
+zero-noise by default and easy to rip out:
+
+```rust
+if std::env::var("VM_TRACE").is_ok() { eprintln!("[vm] pc={pc} op={op:?}"); }
+```
+
+Trace VM opcodes and host calls (`stop`/`play`/`goto_frame`) to find *who*
+issues an unexpected action and *how often*. "Same action fires every frame"
+usually points at a loop or an over-eager per-frame pass.
+
+### 4. Check whether it's a regression
+
+Use `git log -S "<unique code snippet>" --all` and `git show <commit>` to find
+when the suspect code was introduced and why. This distinguishes a recent
+regression from long-standing latent code.
+
+### 5. Lock it in with a deterministic regression test
+
+Add an `#[ignore]`d test to `tests/smoke.rs` (it needs local assets via
+`NATIVE32_GAME_DIR`; see `gunfire_menu_advances_on_confirm` for the pattern).
+
+- **Assert the bug's semantic outcome, not a surface symptom.** Example: assert
+  the menu actually advances (loaded content switches), not "the framebuffer
+  changed" — an animated background can keep pixels changing while the logic is
+  frozen, giving false confidence.
+- **Verify the test catches the bug.** Temporarily revert the fix
+  (`git checkout HEAD~1 -- <file>`), confirm the new test fails, then restore the
+  fix. A regression test that never fails on the buggy code is worthless.
+
+Run with:
+
+```text
+cargo test -p native32emu-core --release --test smoke -- --ignored --nocapture
+```

--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -122,33 +122,6 @@ impl Emulator {
                         .run(&mut (*self_ptr).reader, &mut *self_ptr, action_idx, "");
                 }
             }
-
-            // Then execute movie actions
-            let movie_action_list: Vec<(String, u32)> = {
-                let mut list = Vec::new();
-                let names: Vec<String> = self.sprites.sprites.keys().cloned().collect();
-                for name in &names {
-                    if let Some(movie) = self.sprites.get(name) {
-                        let movie_frames = self.reader.get_movie(movie.movie);
-                        if movie.frame < movie_frames.len() {
-                            let mf = &movie_frames[movie.frame];
-                            if mf.action != 0 {
-                                list.push((name.clone(), mf.action as u32));
-                            }
-                        }
-                    }
-                }
-                list
-            };
-
-            let self_ptr = self as *mut Emulator;
-            unsafe {
-                for (name, action_idx) in movie_action_list {
-                    (*self_ptr)
-                        .vm
-                        .run(&mut (*self_ptr).reader, &mut *self_ptr, action_idx, &name);
-                }
-            }
         }
 
         // Advance movie frames

--- a/crates/native32emu-core/tests/smoke.rs
+++ b/crates/native32emu-core/tests/smoke.rs
@@ -141,3 +141,106 @@ fn run_one(path: &Path) -> Result<bool, String> {
 
     Ok(frame_has_content(emu.get_framebuffer()))
 }
+
+// ---------------------------------------------------------------------------
+// Scripted-input regression harness
+//
+// GUI / interaction bugs (e.g. "pressing a key on a menu freezes the screen")
+// are hard to catch with the plain smoke test because that test never feeds any
+// input. The helpers below turn such interactions into deterministic, headless
+// regression tests: input is scripted per-frame and the emulator core is driven
+// directly, so there is no window and no timing dependency. The Action VM is
+// seeded deterministically, so a given input script always produces the same
+// run.
+// ---------------------------------------------------------------------------
+
+/// Native32 keycode for the Z / "A" button (menu confirm).
+const KEY_Z: u16 = 0x4000;
+
+/// Locate a game asset by file name (case-insensitive) under `dir`.
+fn find_asset(dir: &Path, file_name: &str) -> Option<PathBuf> {
+    let mut all = Vec::new();
+    collect_games(dir, &mut all);
+    all.into_iter().find(|p| {
+        p.file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.eq_ignore_ascii_case(file_name))
+    })
+}
+
+/// Drive a game headlessly with a per-frame input script.
+///
+/// `input_for_frame(frame)` returns the Native32 keycodes held during that
+/// frame. The closure is called for every frame from 0 to `frames - 1`. The
+/// returned emulator can be inspected for final state (loaded content, sprite
+/// positions, etc.).
+fn run_scripted<F>(path: &Path, frames: u32, mut input_for_frame: F) -> Result<Emulator, String>
+where
+    F: FnMut(u32) -> Vec<u16>,
+{
+    let mut emu =
+        Emulator::from_path(path.to_path_buf(), 100).map_err(|e| format!("failed to load: {e}"))?;
+    for frame in 0..frames {
+        let pressed = input_for_frame(frame);
+        emu.set_buttons(&pressed);
+        emu.handle_buttons();
+        emu.tick();
+        emu.draw();
+    }
+    Ok(emu)
+}
+
+/// Regression test for the GunFire menu freeze: holding the confirm button on
+/// the start menu must navigate to the next screen instead of freezing.
+///
+/// Previously a redundant per-frame movie-action pass kept re-issuing the
+/// `Stop` keyframe action of the selection movie, so its confirm animation
+/// never advanced and the menu never progressed. We assert the loaded content
+/// actually switches once confirm is held.
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn gunfire_menu_advances_on_confirm() {
+    let dir = match game_dir() {
+        Some(d) => d,
+        None => {
+            eprintln!("skipping: no game directory found (set NATIVE32_GAME_DIR)");
+            return;
+        }
+    };
+
+    let menu = match find_asset(&dir, "GFSTART.SSL") {
+        Some(p) => p,
+        None => {
+            eprintln!("skipping: GFSTART.SSL not found under {}", dir.display());
+            return;
+        }
+    };
+
+    // Warm up for 40 frames with no input so the menu is fully shown, then hold
+    // the confirm button. The selection animation should play and the menu
+    // should load the next screen, i.e. the loaded content file changes.
+    const WARMUP: u32 = 40;
+    const TOTAL: u32 = 160;
+
+    let emu = run_scripted(&menu, TOTAL, |frame| {
+        if frame >= WARMUP {
+            vec![KEY_Z]
+        } else {
+            vec![]
+        }
+    })
+    .expect("run gunfire menu");
+
+    let final_name = emu
+        .filename
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("")
+        .to_string();
+
+    assert!(
+        !final_name.eq_ignore_ascii_case("GFSTART.SSL"),
+        "menu did not advance after holding confirm: still on {final_name} \
+         (selection animation appears frozen)"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the GunFire menu freezing after pressing **Z** (confirm). The same root cause affects both the standalone and the libretro/RetroArch builds, since they share the emulator core.

## Symptom

When the GunFire menu is shown, pressing **Z** freezes the picture. The emulator keeps running at 30fps (no panic, no hang), but the menu never advances to the next screen, so it appears frozen.

## When the bug was introduced

This bug has been present since the very first Rust implementation of the emulator:

- **Introduced in:** `7da19c2` "Implement Native32 game emulator in Rust" (the initial implementation commit).
- Later commits only moved the code around without changing its logic:
  - `9feda2d` "feat: add libretro core for RetroArch integration" (copied into the libretro path)
  - `13207ab` "refactor(core): merge duplicated standalone/libretro Emulator into one shared core" (merged into the shared core)
  - `769ae93` "refactor(structure): group sources into core/, standalone/ and libretro/" (directory restructure)

It was not added to fix a specific issue; it was a redundant block that happened to be harmless for most games and only surfaced with this particular menu interaction.

## Root cause

In `Emulator::tick()`, every time the main timeline switched to a new frame, the code ran an extra pass that iterated over **all** movie sprites and re-executed the keyframe action of each movie's **current** frame. This was in addition to the correct logic later in the same tick, which runs a movie's keyframe action only when that movie actually advances to a new frame.

The GunFire title screen loops between two main-timeline frames, so this extra pass fired on essentially every tick. The problem becomes visible with a movie that is parked on a keyframe carrying a `Stop` action:

1. The menu selection movie (`mOpt`) sits on its frame `7`, whose keyframe action is `Stop`.
2. Pressing **Z** runs the button action, which does `GotoFrame` + `Play` to start the selection animation.
3. But within the same tick, the redundant pass re-runs `mOpt`'s current-frame `Stop` action, immediately stopping the movie again.
4. As a result `mOpt`'s animation never advances. The menu state machine waits for `mOpt`'s `currentframe` to reach a specific value before loading the next screen, and since the animation is stuck, that condition is never met and the screen appears frozen.

Most movies have `action == 0` on their frames, which is why this latent bug went unnoticed until a movie stopped on a `Stop` keyframe.

## Fix

Remove the redundant "execute movie actions" pass from the main-timeline frame-switch branch in `tick()`. Movie keyframe actions are now executed only when a movie advances to a new frame, which is already handled later in the same tick.

With this change, pressing **Z** lets the `mOpt` selection animation play through normally; it reaches the awaited frame, and the menu loads the next screen as expected.

## Verification

- All 175 core unit tests pass.
- The full smoke test over the local game assets passes for every game (no panic, no blank frame), confirming no regression.
- Manually reproduced the original freeze and confirmed it is resolved after the change: the selection animation advances and content switches to the next screen.