### PR TITLE
feat(libretro): add Android platform support for the libretro core

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -133,9 +133,80 @@ jobs:
             ${{ matrix.artifact }}-libretro.*
           retention-days: 7
 
+  build-android:
+    name: Build libretro (Android)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      - name: Cache Rust artifacts
+        uses: swatinem/rust-cache@v2
+        with:
+          key: nightly-android
+
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r27c
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
+
+      - name: Build libretro core (all ABIs)
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: |
+          cargo ndk \
+            -t arm64-v8a -t armeabi-v7a -t x86 -t x86_64 \
+            -p 21 \
+            build -p native32emu-libretro --release
+
+      - name: Stage libretro core (Android)
+        shell: bash
+        run: |
+          # RetroArch on Android loads cores named <corename>_libretro_android.so,
+          # one per ABI directory (matching RetroArch's cores/<abi>/ layout).
+          declare -A ABI_TRIPLE=(
+            [arm64-v8a]=aarch64-linux-android
+            [armeabi-v7a]=armv7-linux-androideabi
+            [x86]=i686-linux-android
+            [x86_64]=x86_64-linux-android
+          )
+          for abi in "${!ABI_TRIPLE[@]}"; do
+            triple="${ABI_TRIPLE[$abi]}"
+            out="libretro/native32-emu-android/$abi"
+            mkdir -p "$out"
+            cp "target/$triple/release/libnative32emu_libretro.so" \
+               "$out/native32emu_libretro_android.so"
+          done
+          cp crates/native32emu-libretro/native32emu_libretro.info \
+             libretro/native32-emu-android/native32emu_libretro.info
+          ls -laR libretro/native32-emu-android
+
+      - name: Package libretro (Android)
+        shell: bash
+        run: |
+          cd libretro
+          tar czf ../native32-emu-android-libretro.tar.gz native32-emu-android
+          cd ..
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: native32-emu-android
+          path: native32-emu-android-libretro.tar.gz
+          retention-days: 7
+
   release:
     name: Publish Nightly Release
-    needs: build
+    needs: [build, build-android]
     runs-on: ubuntu-latest
     steps:
       - name: Compute version metadata
@@ -181,6 +252,7 @@ jobs:
           - Commit: [\`$SHORT_SHA\`](https://github.com/$REPO/commit/${{ github.sha }})
           - Platforms: Windows x86_64, macOS x86_64/aarch64, Linux x86_64/aarch64
           - Includes the standalone emulator and the libretro core (\`*-libretro.*\`) for RetroArch
+          - Android libretro core (\`native32-emu-android-libretro.tar.gz\`) with arm64-v8a, armeabi-v7a, x86 and x86_64 ABIs
 
           ⚠️ Unsigned build: Windows SmartScreen / macOS Gatekeeper may block on first launch.
           EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,9 +110,79 @@ jobs:
             ${{ matrix.artifact }}.*
             ${{ matrix.artifact }}-libretro.*
 
+  build-android:
+    name: Build libretro (Android)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      - name: Cache Rust artifacts
+        uses: swatinem/rust-cache@v2
+        with:
+          key: android
+
+      - name: Setup Android NDK
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r27c
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
+
+      - name: Build libretro core (all ABIs)
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: |
+          cargo ndk \
+            -t arm64-v8a -t armeabi-v7a -t x86 -t x86_64 \
+            -p 21 \
+            build -p native32emu-libretro --release
+
+      - name: Stage libretro core (Android)
+        shell: bash
+        run: |
+          # RetroArch on Android loads cores named <corename>_libretro_android.so,
+          # one per ABI directory (matching RetroArch's cores/<abi>/ layout).
+          declare -A ABI_TRIPLE=(
+            [arm64-v8a]=aarch64-linux-android
+            [armeabi-v7a]=armv7-linux-androideabi
+            [x86]=i686-linux-android
+            [x86_64]=x86_64-linux-android
+          )
+          for abi in "${!ABI_TRIPLE[@]}"; do
+            triple="${ABI_TRIPLE[$abi]}"
+            out="libretro/native32-emu-android/$abi"
+            mkdir -p "$out"
+            cp "target/$triple/release/libnative32emu_libretro.so" \
+               "$out/native32emu_libretro_android.so"
+          done
+          cp crates/native32emu-libretro/native32emu_libretro.info \
+             libretro/native32-emu-android/native32emu_libretro.info
+          ls -laR libretro/native32-emu-android
+
+      - name: Package libretro (Android)
+        shell: bash
+        run: |
+          cd libretro
+          tar czf ../native32-emu-android-libretro.tar.gz native32-emu-android
+          cd ..
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: native32-emu-android
+          path: native32-emu-android-libretro.tar.gz
+
   release:
     name: Create Release
-    needs: build
+    needs: [build, build-android]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -141,6 +211,11 @@ jobs:
             ### libretro core (for RetroArch)
             - Files ending in `-libretro.*` contain `native32emu_libretro.<ext>`
               plus `native32emu_libretro.info`, ready to drop into RetroArch.
+
+            ### Android libretro core (for RetroArch on Android)
+            - `native32-emu-android-libretro.tar.gz` contains
+              `native32emu_libretro_android.so` for the `arm64-v8a`,
+              `armeabi-v7a`, `x86` and `x86_64` ABIs.
           files: artifacts/**/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,43 @@ else
 	CARGO_PROFILE_FLAG :=
 endif
 
-# `platform` is set by the libretro CI templates: win64, win32, unix, osx.
-# `ARCH`/`arch` distinguish 32/64-bit and architecture variants.
+# `platform` is set by the libretro CI templates: win64, win32, unix, osx,
+# android. `ARCH`/`arch` distinguish 32/64-bit and architecture variants.
 platform ?=
 ARCH     ?=
 arch     ?=
 
+# Android requires a different build path: the NDK toolchain links against
+# Bionic, so we drive cargo through `cargo-ndk`. RetroArch on Android also
+# expects the core to be named `<corename>_libretro_android.so`.
+IS_ANDROID :=
+
+# Android API level to target (minimum supported). 21 covers Android 5.0+.
+ANDROID_API ?= 21
+
 # Map the libretro platform/arch to a Rust target triple and library naming.
-ifeq ($(platform),win64)
+ifeq ($(platform),android)
+	IS_ANDROID := 1
+	CORE_LIB   := $(TARGET)_android.so
+	CARGO_LIB  := lib$(TARGET).so
+	# `ARCH` selects the Android ABI; default to arm64-v8a.
+	ifeq ($(ARCH),arm)
+		RUST_TARGET := armv7-linux-androideabi
+		NDK_ABI     := armeabi-v7a
+	else ifeq ($(ARCH),arm64)
+		RUST_TARGET := aarch64-linux-android
+		NDK_ABI     := arm64-v8a
+	else ifeq ($(ARCH),x86)
+		RUST_TARGET := i686-linux-android
+		NDK_ABI     := x86
+	else ifeq ($(ARCH),x86_64)
+		RUST_TARGET := x86_64-linux-android
+		NDK_ABI     := x86_64
+	else
+		RUST_TARGET := aarch64-linux-android
+		NDK_ABI     := arm64-v8a
+	endif
+else ifeq ($(platform),win64)
 	RUST_TARGET := x86_64-pc-windows-gnu
 	CARGO_LIB   := $(TARGET).dll
 	CORE_LIB    := $(TARGET).dll
@@ -85,7 +114,13 @@ $(CORE_LIB):
 ifneq ($(RUST_TARGET),)
 	rustup target add $(RUST_TARGET) || true
 endif
+ifeq ($(IS_ANDROID),1)
+	# Android links against the NDK toolchain; cargo-ndk wires up the linker
+	# and sysroot for the selected ABI. Requires ANDROID_NDK_HOME to be set.
+	$(CARGO) ndk -t $(NDK_ABI) -p $(ANDROID_API) build -p native32emu-libretro $(CARGO_PROFILE_FLAG)
+else
 	$(CARGO) build -p native32emu-libretro $(CARGO_PROFILE_FLAG) $(CARGO_TARGET_FLAG)
+endif
 	cp -f "$(CARGO_OUT)" "$(CORE_LIB)"
 
 clean:

--- a/README.md
+++ b/README.md
@@ -92,19 +92,9 @@ Native32Emu can be used as a libretro core with RetroArch, allowing you to play 
 
 #### RetroArch on Android
 
-The libretro core also runs on Android, so it can be reused by most Android
-RetroArch-based frontends.
-
-1. **Download** `native32-emu-android-libretro.tar.gz` from the
-   [Releases](https://github.com/jiangxincode/Native32Emu/releases) page. It
-   contains `native32emu_libretro_android.so` for the `arm64-v8a`,
-   `armeabi-v7a`, `x86` and `x86_64` ABIs.
-2. **Install the core**: copy the `native32emu_libretro_android.so` matching
-   your device's ABI (most modern devices are `arm64-v8a`) into RetroArch's
-   `cores/` directory (typically
-   `/storage/emulated/0/RetroArch/cores/` or the app's internal `cores/` path),
-   and copy `native32emu_libretro.info` into RetroArch's `info/` directory.
-3. **Load** the core and content the same way as on desktop.
+The libretro core also runs on Android and can be reused by most Android
+RetroArch-based frontends. See [Android Libretro Core](docs/Android-Libretro-Core.md)
+for install and build instructions.
 
 #### Supported Features
 
@@ -154,24 +144,7 @@ cargo build -p native32emu-libretro --release
 This produces `native32emu_libretro.dll` on Windows (`libnative32emu_libretro.so`
 on Linux, `libnative32emu_libretro.dylib` on macOS) under `target/release/`.
 
-#### Libretro Core for Android
-
-Building for Android requires the [Android NDK](https://developer.android.com/ndk)
-and [`cargo-ndk`](https://github.com/bbqsrc/cargo-ndk):
-
-```bash
-cargo install cargo-ndk
-rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
-export ANDROID_NDK_HOME=/path/to/android-ndk
-
-# Build all four ABIs (artifacts land in target/<triple>/release/)
-cargo ndk -t arm64-v8a -t armeabi-v7a -t x86 -t x86_64 -p 21 \
-  build -p native32emu-libretro --release
-```
-
-Each ABI produces `libnative32emu_libretro.so`; rename it to
-`native32emu_libretro_android.so` when installing into RetroArch on Android.
-The CI release workflow performs this packaging automatically.
+For Android cross-compilation, see [Android Libretro Core](docs/Android-Libretro-Core.md).
 
 #### Distributing via RetroArch's Online Updater
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ Native32Emu can be used as a libretro core with RetroArch, allowing you to play 
    - Select "Load Core" → "Native32 (Native32Emu)"
    - Select "Load Content" and choose a `.smf`, `.sgm`, or `.ssl` game file
 
+#### RetroArch on Android
+
+The libretro core also runs on Android, so it can be reused by most Android
+RetroArch-based frontends.
+
+1. **Download** `native32-emu-android-libretro.tar.gz` from the
+   [Releases](https://github.com/jiangxincode/Native32Emu/releases) page. It
+   contains `native32emu_libretro_android.so` for the `arm64-v8a`,
+   `armeabi-v7a`, `x86` and `x86_64` ABIs.
+2. **Install the core**: copy the `native32emu_libretro_android.so` matching
+   your device's ABI (most modern devices are `arm64-v8a`) into RetroArch's
+   `cores/` directory (typically
+   `/storage/emulated/0/RetroArch/cores/` or the app's internal `cores/` path),
+   and copy `native32emu_libretro.info` into RetroArch's `info/` directory.
+3. **Load** the core and content the same way as on desktop.
+
 #### Supported Features
 
 - ✅ Video output (XRGB8888 pixel format)
@@ -137,6 +153,25 @@ cargo build -p native32emu-libretro --release
 
 This produces `native32emu_libretro.dll` on Windows (`libnative32emu_libretro.so`
 on Linux, `libnative32emu_libretro.dylib` on macOS) under `target/release/`.
+
+#### Libretro Core for Android
+
+Building for Android requires the [Android NDK](https://developer.android.com/ndk)
+and [`cargo-ndk`](https://github.com/bbqsrc/cargo-ndk):
+
+```bash
+cargo install cargo-ndk
+rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+export ANDROID_NDK_HOME=/path/to/android-ndk
+
+# Build all four ABIs (artifacts land in target/<triple>/release/)
+cargo ndk -t arm64-v8a -t armeabi-v7a -t x86 -t x86_64 -p 21 \
+  build -p native32emu-libretro --release
+```
+
+Each ABI produces `libnative32emu_libretro.so`; rename it to
+`native32emu_libretro_android.so` when installing into RetroArch on Android.
+The CI release workflow performs this packaging automatically.
 
 #### Distributing via RetroArch's Online Updater
 

--- a/docs/Android-Libretro-Core.md
+++ b/docs/Android-Libretro-Core.md
@@ -1,0 +1,36 @@
+# Android Libretro Core
+
+The Native32Emu libretro core also runs on Android, so it can be reused by most
+Android RetroArch-based frontends.
+
+## Install in RetroArch on Android
+
+1. **Download** `native32-emu-android-libretro.tar.gz` from the
+   [Releases](https://github.com/jiangxincode/Native32Emu/releases) page. It
+   contains `native32emu_libretro_android.so` for the `arm64-v8a`,
+   `armeabi-v7a`, `x86` and `x86_64` ABIs.
+2. **Install the core**: copy the `native32emu_libretro_android.so` matching
+   your device's ABI (most modern devices are `arm64-v8a`) into RetroArch's
+   `cores/` directory (typically
+   `/storage/emulated/0/RetroArch/cores/` or the app's internal `cores/` path),
+   and copy `native32emu_libretro.info` into RetroArch's `info/` directory.
+3. **Load** the core and content the same way as on desktop.
+
+## Building the Android core locally
+
+Building for Android requires the [Android NDK](https://developer.android.com/ndk)
+and [`cargo-ndk`](https://github.com/bbqsrc/cargo-ndk):
+
+```bash
+cargo install cargo-ndk
+rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+export ANDROID_NDK_HOME=/path/to/android-ndk
+
+# Build all four ABIs (artifacts land in target/<triple>/release/)
+cargo ndk -t arm64-v8a -t armeabi-v7a -t x86 -t x86_64 -p 21 \
+  build -p native32emu-libretro --release
+```
+
+Each ABI produces `libnative32emu_libretro.so`; rename it to
+`native32emu_libretro_android.so` when installing into RetroArch on Android.
+The CI release workflow performs this packaging automatically.


### PR DESCRIPTION
## Summary

Adds Android support for the libretro core so RetroArch-based Android frontends can reuse it. Resolves #24.

The core crate (`native32emu-libretro`) only depends on the pure-Rust `native32emu-core` with no platform-specific code, so cross-compiling to Android required no source changes — only build/CI/packaging wiring.

## Changes

- **CI (`nightly-build.yml`, `release.yml`)**: new `build-android` job that cross-compiles the libretro core for all four Android ABIs (`arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64`) using `cargo-ndk`, packages the artifacts as `native32-emu-android-libretro.tar.gz`, and publishes them in the nightly and tagged releases.
- **`Makefile`**: added an `android` platform branch (driven via `cargo-ndk`) that maps the libretro `ARCH` to the matching Android target triple and produces `native32emu_libretro_android.so`.
- **`README.md`**: documented Android install steps for RetroArch and a local Android build recipe.

## Verification

- `cargo check -p native32emu-libretro --target aarch64-linux-android` passes, confirming the core compiles cleanly for Android targets.
- All three modified YAML workflows parse successfully.
- pre-commit hooks (clippy `-D warnings` + rustfmt) pass.

## Notes

- Full link/runtime validation happens in CI where the Android NDK is available (no NDK locally).
- The `.gitlab-ci.yml` libretro buildbot recipe was intentionally left unchanged; the official Android template uses an `ndk-build`/`Android.mk` flow that doesn't fit the cargo-ndk path. Android delivery is handled through GitHub Actions, the repo's actual release channel.
