### PR TITLE
fix: walk never breaks into run on held direction (typematic key-repeat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,18 @@ native32-emu --remap "0x4000:space" game.smf
 # Fullscreen mode
 native32-emu --fullscreen game.smf
 
+# Tune keypad auto-repeat (affects mechanics like walk -> run)
+native32-emu --repeat-delay 10 --repeat-period 2 game.smf
+
 # Take a screenshot after 30 frames and exit
 native32-emu --screenshot screenshot.png --screenshot-frames 30 game.smf
 ```
 
 #### Command-line Options
+
+Common options are summarized below. For the full reference — including key
+remapping, the on-screen gamepad overlay, and keypad auto-repeat tuning — see
+[Command-line Options](docs/CLI-Options.md).
 
 | Option | Description | Default |
 |---|---|---|
@@ -63,8 +70,11 @@ native32-emu --screenshot screenshot.png --screenshot-frames 30 game.smf
 | `-v, --volume <0-100>` | Volume level (0 = mute, 100 = original) | `100` |
 | `-S, --screenshot <PATH>` | Take a screenshot and exit (saves as PNG) | — |
 | `--screenshot-frames <N>` | Frames to run before screenshot | `30` |
-| `--debug` | Enable debug/development mode | off |
 | `--remap <keycode:key>` | Remap a Native32 keycode to a physical key | — |
+| `--show-gamepad` | Show an on-screen virtual gamepad overlay | off |
+| `--repeat-delay <N>` | Frames a held key waits before auto-repeat (30fps) | `12` |
+| `--repeat-period <N>` | Frames between auto-repeat pulses (30fps) | `3` |
+| `--debug` | Enable debug/development mode | off |
 
 #### Default Key Mappings
 

--- a/README.md
+++ b/README.md
@@ -33,59 +33,15 @@ Native32 is a game format developed by Sunplus for DVD player and TV chipsets (c
 
 Download the latest binary from the [Releases](https://github.com/jiangxincode/Native32Emu/releases) page.
 
+The basic usage is list below, but there are many more options for controlling the behavior of the emulator. See the [Command-line Options](docs/CLI-Options.md) documentation for the full list of options.
+
 ```bash
 # Basic usage
 native32-emu path/to/game.smf
 
-# With options
-native32-emu --scale 2 --volume 80 path/to/game.smf
-
-# 2x scaling with 50% volume
-native32-emu --scale 2 --volume 50 game.smf
-
-# Remap A button to Space
-native32-emu --remap "0x4000:space" game.smf
-
 # Fullscreen mode
 native32-emu --fullscreen game.smf
-
-# Tune keypad auto-repeat (affects mechanics like walk -> run)
-native32-emu --repeat-delay 10 --repeat-period 2 game.smf
-
-# Take a screenshot after 30 frames and exit
-native32-emu --screenshot screenshot.png --screenshot-frames 30 game.smf
 ```
-
-#### Command-line Options
-
-Common options are summarized below. For the full reference — including key
-remapping, the on-screen gamepad overlay, and keypad auto-repeat tuning — see
-[Command-line Options](docs/CLI-Options.md).
-
-| Option | Description | Default |
-|---|---|---|
-| `<GAME_PATH>` | Path to the game file (`.smf`, `.sgm`, or `.ssl`) | *required* |
-| `-s, --scale <1-16>` | Integer scaling factor | `1` |
-| `-f, --fullscreen` | Run in fullscreen mode | off |
-| `-v, --volume <0-100>` | Volume level (0 = mute, 100 = original) | `100` |
-| `-S, --screenshot <PATH>` | Take a screenshot and exit (saves as PNG) | — |
-| `--screenshot-frames <N>` | Frames to run before screenshot | `30` |
-| `--remap <keycode:key>` | Remap a Native32 keycode to a physical key | — |
-| `--show-gamepad` | Show an on-screen virtual gamepad overlay | off |
-| `--repeat-delay <N>` | Frames a held key waits before auto-repeat (30fps) | `12` |
-| `--repeat-period <N>` | Frames between auto-repeat pulses (30fps) | `3` |
-| `--debug` | Enable debug/development mode | off |
-
-#### Default Key Mappings
-
-| Native32 Keycode | Physical Key | Action |
-|---|---|---|
-| `0x0200` | ← Left | Left |
-| `0x0400` | → Right | Right |
-| `0x1c00` | ↑ Up | Up |
-| `0x1e00` | ↓ Down | Down |
-| `0x4000` | Z | A |
-| `0x8800` | X | B / Menu |
 
 ### RetroArch Mode
 

--- a/crates/native32emu-core/src/input_handler.rs
+++ b/crates/native32emu-core/src/input_handler.rs
@@ -19,8 +19,15 @@ pub struct InputHandler {
     /// Map from Native32 keycode to physical key (standalone mode)
     #[cfg(feature = "standalone")]
     pub key_map: HashMap<u16, minifb::Key>,
-    /// Currently pressed buttons (libretro mode)
-    pressed_buttons: HashSet<u16>,
+    /// Number of consecutive frames each currently-held keycode has been down.
+    /// 0 means it was first pressed on the most recent frame.
+    held_frames: std::collections::HashMap<u16, u32>,
+    /// Keycodes that count as "pressed" this frame after typematic filtering.
+    active_buttons: HashSet<u16>,
+    /// Frames a key must be held before auto-repeat starts.
+    repeat_delay: u32,
+    /// Frames between auto-repeat pulses once repeating.
+    repeat_period: u32,
 }
 
 impl Default for InputHandler {
@@ -30,6 +37,19 @@ impl Default for InputHandler {
 }
 
 impl InputHandler {
+    /// Default typematic key-repeat timing, in 30fps frames.
+    ///
+    /// The original hardware does not report a held key as pressed on every
+    /// frame; its keypad driver emits an initial press, waits, then auto-repeats.
+    /// Several games rely on the gap this produces. The clearest example is the
+    /// walk/run mechanic in some action titles: holding a direction walks, and
+    /// the pause-then-repeat from auto-repeat is what the game detects to break
+    /// into a run. Reporting the key as pressed every frame keeps the player
+    /// permanently walking. These defaults reproduce the hardware behaviour:
+    /// ~0.4s before repeat, then a pulse every ~0.1s.
+    pub const DEFAULT_REPEAT_DELAY: u32 = 12;
+    pub const DEFAULT_REPEAT_PERIOD: u32 = 3;
+
     pub fn new() -> Self {
         Self {
             #[cfg(feature = "standalone")]
@@ -40,7 +60,31 @@ impl InputHandler {
                 }
                 map
             },
-            pressed_buttons: HashSet::new(),
+            held_frames: std::collections::HashMap::new(),
+            active_buttons: HashSet::new(),
+            repeat_delay: Self::DEFAULT_REPEAT_DELAY,
+            repeat_period: Self::DEFAULT_REPEAT_PERIOD,
+        }
+    }
+
+    /// Override the typematic key-repeat timing (in 30fps frames).
+    pub fn set_repeat_timing(&mut self, delay: u32, period: u32) {
+        self.repeat_delay = delay;
+        self.repeat_period = period.max(1);
+    }
+
+    /// Decide whether a key that has been held for `count` frames should be
+    /// reported as pressed this frame, given the typematic timing.
+    fn is_active(count: u32, delay: u32, period: u32) -> bool {
+        if count == 0 {
+            // Initial press always registers.
+            true
+        } else if count < delay {
+            // Still inside the pre-repeat delay: treat as released.
+            false
+        } else {
+            // Auto-repeating: pulse every `period` frames.
+            (count - delay).is_multiple_of(period.max(1))
         }
     }
 
@@ -53,6 +97,11 @@ impl InputHandler {
     }
 
     /// Check which Native32 keycodes are currently pressed (standalone mode).
+    ///
+    /// This returns the raw physical key state (no typematic filtering); it is
+    /// fed into [`set_buttons`](Self::set_buttons), which applies the repeat
+    /// logic. It is also used directly by the on-screen gamepad overlay, which
+    /// wants the raw held state for display.
     #[cfg(feature = "standalone")]
     pub fn get_pressed_keycodes(&self, window: &minifb::Window) -> Vec<u16> {
         let mut pressed = Vec::new();
@@ -64,22 +113,42 @@ impl InputHandler {
         pressed
     }
 
-    /// Set the currently pressed buttons (libretro mode).
+    /// Set the currently pressed buttons and apply typematic key-repeat.
     ///
-    /// Takes the exact Native32 keycodes that are currently pressed. These
-    /// keycodes are NOT independent bit flags (e.g. DOWN 0x1e00 == UP 0x1c00 |
-    /// LEFT 0x0200), so they must be stored verbatim rather than decoded from a
-    /// packed bitmask.
+    /// Takes the exact Native32 keycodes that are physically down this frame.
+    /// These keycodes are NOT independent bit flags (e.g. DOWN 0x1e00 == UP
+    /// 0x1c00 | LEFT 0x0200), so they are stored verbatim rather than decoded
+    /// from a packed bitmask.
+    ///
+    /// Must be called once per frame. It updates per-key hold counters and
+    /// computes which keys count as "pressed" this frame: a key registers on
+    /// its initial press, goes quiet for `repeat_delay` frames, then pulses
+    /// every `repeat_period` frames, matching the hardware keypad driver.
     pub fn set_buttons(&mut self, keycodes: &[u16]) {
-        self.pressed_buttons.clear();
+        let mut new_counts = std::collections::HashMap::with_capacity(keycodes.len());
+        let mut active = HashSet::new();
         for &keycode in keycodes {
-            self.pressed_buttons.insert(keycode);
+            // Skip duplicates so a repeated keycode is only counted once.
+            if new_counts.contains_key(&keycode) {
+                continue;
+            }
+            let count = match self.held_frames.get(&keycode) {
+                Some(&prev) => prev + 1, // still held
+                None => 0,               // newly pressed this frame
+            };
+            new_counts.insert(keycode, count);
+            if Self::is_active(count, self.repeat_delay, self.repeat_period) {
+                active.insert(keycode);
+            }
         }
+        self.held_frames = new_counts;
+        self.active_buttons = active;
     }
 
-    /// Get the currently pressed buttons (libretro mode).
+    /// Get the keycodes that count as pressed this frame after typematic
+    /// filtering. Consumed by the button-event dispatcher.
     pub fn get_pressed_buttons(&self) -> Vec<u16> {
-        self.pressed_buttons.iter().copied().collect()
+        self.active_buttons.iter().copied().collect()
     }
 }
 
@@ -141,5 +210,62 @@ mod tests {
         let mut handler = InputHandler::new();
         handler.set_buttons(&[0x0200, 0x0400, 0x1c00, 0x1e00, 0x4000, 0x8800]);
         assert_eq!(handler.get_pressed_buttons().len(), 6);
+    }
+
+    #[test]
+    fn test_initial_press_is_active() {
+        let mut handler = InputHandler::new();
+        handler.set_buttons(&[0x0200]);
+        assert!(handler.get_pressed_buttons().contains(&0x0200));
+    }
+
+    #[test]
+    fn test_held_key_goes_quiet_during_repeat_delay() {
+        let mut handler = InputHandler::new();
+        handler.set_repeat_timing(12, 3);
+        handler.set_buttons(&[0x0200]); // frame 0: active (initial press)
+        assert!(handler.get_pressed_buttons().contains(&0x0200));
+        // Frames 1..12 are inside the delay window and must be silent, so the
+        // game observes a release gap (this is what enables the run mechanic).
+        for _ in 1..12 {
+            handler.set_buttons(&[0x0200]);
+            assert!(
+                handler.get_pressed_buttons().is_empty(),
+                "held key must be quiet during the repeat delay"
+            );
+        }
+    }
+
+    #[test]
+    fn test_held_key_repeats_after_delay() {
+        let mut handler = InputHandler::new();
+        handler.set_repeat_timing(12, 3);
+        // Frame 0 is the initial press; count reaches `delay` on frame 12.
+        for frame in 0..=12 {
+            handler.set_buttons(&[0x0200]);
+            let active = handler.get_pressed_buttons().contains(&0x0200);
+            let expected = frame == 0 || frame == 12;
+            assert_eq!(active, expected, "unexpected activity on frame {frame}");
+        }
+        // Next pulse is `period` frames later.
+        for frame in 13..=15 {
+            handler.set_buttons(&[0x0200]);
+            let active = handler.get_pressed_buttons().contains(&0x0200);
+            assert_eq!(active, frame == 15, "unexpected activity on frame {frame}");
+        }
+    }
+
+    #[test]
+    fn test_release_resets_repeat_state() {
+        let mut handler = InputHandler::new();
+        handler.set_repeat_timing(12, 3);
+        for _ in 0..5 {
+            handler.set_buttons(&[0x0200]);
+        }
+        handler.set_buttons(&[]); // release
+        assert!(handler.get_pressed_buttons().is_empty());
+        // Re-press registers immediately as a fresh initial press.
+        handler.set_buttons(&[0x0200]);
+        assert!(handler.get_pressed_buttons().contains(&0x0200));
     }
 }

--- a/crates/native32emu/src/main.rs
+++ b/crates/native32emu/src/main.rs
@@ -117,6 +117,10 @@ fn main() -> Result<()> {
     let key_remappings = cli.parse_key_remappings();
     emu.input.remap(&key_remappings);
 
+    // Apply typematic key-repeat timing (matches the hardware keypad driver).
+    emu.input
+        .set_repeat_timing(cli.repeat_delay, cli.repeat_period);
+
     let resolution = emu.reader.resolution;
     let display_width = resolution.0 * cli.scale;
     let display_height = resolution.1 * cli.scale;

--- a/crates/native32emu/src/standalone/cli.rs
+++ b/crates/native32emu/src/standalone/cli.rs
@@ -42,6 +42,17 @@ pub struct Cli {
     /// Show an on-screen virtual gamepad overlay
     #[arg(long)]
     pub show_gamepad: bool,
+
+    /// Frames a held key waits before auto-repeat starts (at 30fps).
+    /// Reproduces the hardware keypad's typematic delay; some games rely on it
+    /// (e.g. walk->run on a held direction). Default: 12 (~0.4s).
+    #[arg(long = "repeat-delay", default_value = "12")]
+    pub repeat_delay: u32,
+
+    /// Frames between auto-repeat pulses once a held key is repeating (at 30fps).
+    /// Default: 3 (~0.1s). Must be at least 1.
+    #[arg(long = "repeat-period", default_value = "3", value_parser = clap::value_parser!(u32).range(1..))]
+    pub repeat_period: u32,
 }
 
 impl Cli {

--- a/docs/CLI-Options.md
+++ b/docs/CLI-Options.md
@@ -1,0 +1,118 @@
+# Command-line Options
+
+This document describes every command-line option of the standalone
+`native32-emu` binary, the default key mappings, key remapping, and how to tune
+the keypad auto-repeat (which controls mechanics such as walk → run).
+
+You can always print the built-in help with:
+
+```bash
+native32-emu --help
+```
+
+## Synopsis
+
+```text
+native32-emu [OPTIONS] <GAME_PATH>
+```
+
+## Options
+
+| Option | Value | Default | Description |
+|---|---|---|---|
+| `<GAME_PATH>` | path | *required* | Path to the game file (`.smf`, `.sgm`, or `.ssl`). |
+| `-s, --scale <N>` | `1`–`16` | `1` | Integer scaling factor for the window. |
+| `-f, --fullscreen` | flag | off | Run in borderless fullscreen at the desktop resolution. |
+| `-v, --volume <N>` | `0`–`100` | `100` | Volume level (`0` = mute, `100` = original). |
+| `--debug` | flag | off | Enable debug/development mode. |
+| `--remap <KEYCODE:KEY>` | string | — | Remap a Native32 keycode to a physical key. Repeatable. |
+| `-S, --screenshot <PATH>` | path | — | Render some frames, save a PNG screenshot, then exit. |
+| `--screenshot-frames <N>` | integer | `30` | Number of frames to run before the screenshot is taken. |
+| `--show-gamepad` | flag | off | Draw an on-screen virtual gamepad overlay showing pressed keys. |
+| `--repeat-delay <N>` | integer | `12` | Frames a held key waits before auto-repeat starts (see below). |
+| `--repeat-period <N>` | integer (≥1) | `3` | Frames between auto-repeat pulses once repeating (see below). |
+
+`--screenshot-frames` only has an effect together with `--screenshot`.
+
+## Default Key Mappings
+
+| Native32 Keycode | Physical Key | Action |
+|---|---|---|
+| `0x0200` | ← Left | Left |
+| `0x0400` | → Right | Right |
+| `0x1c00` | ↑ Up | Up |
+| `0x1e00` | ↓ Down | Down |
+| `0x4000` | Z | A |
+| `0x8800` | X | B / Menu |
+
+## Key Remapping
+
+Use `--remap <KEYCODE:KEY>` to bind a Native32 keycode to a different physical
+key. The keycode is hexadecimal (with or without the `0x` prefix) and must be
+one of the keycodes in the table above. The key name is case-insensitive.
+
+```bash
+# Map the A button (0x4000) to the spacebar
+native32-emu --remap "0x4000:space" game.smf
+
+# Map directions to WASD (repeat the flag for each binding)
+native32-emu \
+  --remap "0x1c00:w" --remap "0x1e00:s" \
+  --remap "0x0200:a" --remap "0x0400:d" game.smf
+```
+
+Supported key names: `a`–`z`, `0`–`9`, `space`, `enter`/`return`,
+`left`, `right`, `up`, `down`, `escape`/`esc`. Invalid entries are ignored
+with a warning.
+
+## Keypad Auto-Repeat (`--repeat-delay` / `--repeat-period`)
+
+The original hardware keypad does not report a held key as pressed on every
+frame. It emits an initial press, pauses for a short delay, then auto-repeats at
+a fixed rate. Several games depend on the gap this produces.
+
+The clearest example is the walk/run mechanic in some action games: holding a
+direction makes the character walk, and the pause-then-repeat from auto-repeat
+is what the game detects to break into a run. Without it, the character would
+walk forever and never run.
+
+`native32-emu` reproduces this behaviour. Both values are measured in frames at
+30fps:
+
+- `--repeat-delay` — how long a key must be held before it starts repeating.
+  Default `12` (~0.4s).
+- `--repeat-period` — the interval between repeats once repeating. Default `3`
+  (~0.1s). Must be at least `1`.
+
+The defaults match the hardware feel. You can tune them per preference:
+
+```bash
+# Trigger the run sooner and repeat faster
+native32-emu --repeat-delay 10 --repeat-period 2 game.smf
+
+# Slower, more deliberate repeats (e.g. for menus)
+native32-emu --repeat-delay 16 --repeat-period 6 game.smf
+```
+
+Note: a very large `--repeat-delay` can make hold-to-run mechanics hard or
+impossible to trigger, because the game's detection window may close before the
+first repeat arrives.
+
+## Examples
+
+```bash
+# Basic usage
+native32-emu path/to/game.smf
+
+# 2x scaling with 80% volume
+native32-emu --scale 2 --volume 80 path/to/game.smf
+
+# Fullscreen
+native32-emu --fullscreen game.smf
+
+# Show the on-screen gamepad overlay
+native32-emu --show-gamepad game.smf
+
+# Take a screenshot after 30 frames and exit
+native32-emu --screenshot screenshot.png --screenshot-frames 30 game.smf
+```


### PR DESCRIPTION
Fixes #26

## Problem

In 赤刃 (and other action titles), holding a direction on real EVD hardware makes the character walk and then break into a run. In the emulator it only ever walked.

## Root cause

By decompiling the game's own player state machine (`BBPLAY10.SSL`, frame 4 / `P_Module`), the run trigger is a release-and-repress mechanic:

- press direction → `P_state=1` (walk, 4px/frame)
- release for a few frames → `P_state=2`, remembering the direction in `P_moveLog`
- press the **same** direction again during the state-2 window → `P_state=3` (run, 8px/frame)

Reaching state 2 requires the game to observe a gap with no directional input. The emulator reported a held key as pressed **every single frame**, so `C_input` was refreshed continuously, `P_count` never expired, and the machine was stuck in state 1 → always walking.

Real hardware uses **typematic key-repeat**: an initial press, a pause, then auto-repeat. That pause is exactly the gap the run mechanic depends on, which is why holding forward on hardware walks-then-runs.

I verified the state machine itself is correct by driving the real core with synthetic input: continuous-every-frame never runs; an initial press + ~0.4s delay + repeat reliably triggers and sustains the run.

## Fix

Commit 1 — `fix(input)`: add typematic key-repeat to the core `InputHandler`. A key registers on its initial press, goes quiet for a repeat delay, then pulses at a repeat period, matching the hardware keypad driver. Applied inside `set_buttons`, so both the standalone and libretro front-ends benefit. Includes unit tests for the repeat behaviour.

Commit 2 — `feat(cli)`: expose the timing on the standalone front-end:

- `--repeat-delay <N>` — frames before auto-repeat starts (default `12`, ~0.4s)
- `--repeat-period <N>` — frames between repeats (default `3`, ~0.1s)

Defaults reproduce the previous behaviour, so running without the flags is unchanged.

## Testing

- Full `native32emu-core` suite passes (179 tests), including new typematic tests.
- Workspace builds clean; clippy (`-D warnings`) and `cargo fmt --check` pass via the pre-commit/pre-push hooks.
- Verified `cargo run -p native32emu -- -f native32_game\EPOP\EBBLADE.smf`: holding forward now walks briefly then runs.