### PR TITLE
feat: play SSL_PlayNext MPEG-1 cutscene/logo videos (pure-Rust decoder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Native32 is a game format developed by Sunplus for DVD player and TV chipsets (c
 - **Action bytecode VM** — 36 opcodes covering arithmetic, logic, string ops, control flow, sprites, and I/O
 - **Sprite/movie system** — animation, cloning, visibility control, depth-sorted rendering
 - **Audio playback** — MP3 music and raw 16-bit PCM sound effects
+- **MPEG-1 cutscenes** — pure-Rust MPEG-1 video + MP2 audio decoder plays `SSL_PlayNext` logo/cutscene videos (no C dependency); skippable with A/B
 - **Keyboard input** — configurable key remapping
 - **Save system** — `.ssl_sav` file persistence
 - **SSL multi-file content** — seamless switching between game levels/files

--- a/crates/native32emu-core/src/audio_engine.rs
+++ b/crates/native32emu-core/src/audio_engine.rs
@@ -299,6 +299,58 @@ impl AudioEngine {
         }
     }
 
+    /// Play a fully-decoded interleaved PCM stream (used for cutscene audio).
+    /// `samples` are normalized floats interleaved by `channels`.
+    #[cfg(feature = "standalone")]
+    pub fn play_pcm_stream(&mut self, samples: Vec<f32>, channels: u16, sample_rate: u32) {
+        if samples.is_empty() || channels == 0 || sample_rate == 0 {
+            return;
+        }
+        if let Some(ref mixer) = self.mixer {
+            if let Some(ref player) = self.player {
+                player.stop();
+            }
+            let source = rodio::buffer::SamplesBuffer::new(
+                NonZero::<u16>::new(channels).unwrap(),
+                NonZero::<u32>::new(sample_rate).unwrap(),
+                samples,
+            );
+            let player = rodio::Player::connect_new(mixer);
+            player.set_volume(self.volume);
+            player.append(source);
+            self.player = Some(player);
+            self.music_owner = Some("__cutscene__".to_string());
+        }
+    }
+
+    /// Libretro variant: resample to the engine's output rate and stage the
+    /// samples for `get_pending_samples` to drain.
+    #[cfg(not(feature = "standalone"))]
+    pub fn play_pcm_stream(&mut self, samples: Vec<f32>, channels: u16, sample_rate: u32) {
+        if samples.is_empty() || channels == 0 || sample_rate == 0 {
+            return;
+        }
+        let out_rate = match self.colorspace {
+            Colorspace::YUV => 11025u32,
+            Colorspace::ARGB => 22050u32,
+        };
+        let ch = channels as usize;
+        let in_frames = samples.len() / ch;
+        let out_frames = (in_frames as u64 * out_rate as u64 / sample_rate as u64) as usize;
+        let mut out = Vec::with_capacity(out_frames * 2);
+        for i in 0..out_frames {
+            let src =
+                ((i as u64 * sample_rate as u64 / out_rate as u64) as usize).min(in_frames - 1);
+            let base = src * ch;
+            let l = samples[base];
+            let r = if ch >= 2 { samples[base + 1] } else { l };
+            out.push((l * 32767.0 * self.volume).clamp(-32768.0, 32767.0) as i16);
+            out.push((r * 32767.0 * self.volume).clamp(-32768.0, 32767.0) as i16);
+        }
+        self.pending_samples = out;
+        self.tone_active = false;
+    }
+
     /// Stop all currently playing sounds.
     pub fn stop_all(&mut self) {
         #[cfg(feature = "standalone")]

--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -33,6 +33,11 @@ pub struct Emulator {
     pub cur_frame_objects: Vec<FrameObject>,
     pub tick_count: u64,
     pub time_ms: u32,
+    /// MPEG-1 cutscene videos queued by SSL_PlayNext, played before the next
+    /// SSL content loads.
+    pub pending_videos: Vec<String>,
+    /// Active cutscene player, if a video is currently playing.
+    pub video_player: Option<crate::mpeg::VideoPlayer>,
 }
 
 impl Emulator {
@@ -63,6 +68,8 @@ impl Emulator {
             cur_frame_objects: Vec::new(),
             tick_count: 0,
             time_ms: 0,
+            pending_videos: Vec::new(),
+            video_player: None,
         })
     }
 
@@ -98,6 +105,13 @@ impl Emulator {
     /// Run one tick of the emulation (called at 30fps).
     pub fn tick(&mut self) {
         self.tick_count += 1;
+
+        // While a cutscene is playing (or queued), drive video playback instead
+        // of the normal timeline.
+        if self.is_cutscene_active() {
+            self.cutscene_tick();
+            return;
+        }
 
         // Advance main timeline
         self.frame_player.tick();
@@ -220,11 +234,110 @@ impl Emulator {
         }
 
         // Handle content switching (SSL_PlayNext)
-        if self.content_loader.has_pending() {
+        if self.content_loader.has_pending() && !self.is_cutscene_active() {
             if let Some(filename) = self.content_loader.take_pending() {
                 if let Err(e) = self.switch_content(&filename) {
                     log::error!("Failed to switch content: {}", e);
                 }
+            }
+        }
+    }
+
+    /// Whether a cutscene video is currently playing or queued.
+    pub fn is_cutscene_active(&self) -> bool {
+        self.video_player.is_some() || !self.pending_videos.is_empty()
+    }
+
+    /// Queue MPEG-1 cutscene videos (SSL_PlayNext pre-content) for playback.
+    pub fn queue_videos(&mut self, names: &[&str]) {
+        for name in names {
+            let normalized = normalize_content_path(name);
+            if !normalized.is_empty() {
+                self.pending_videos.push(normalized);
+            }
+        }
+    }
+
+    /// Skip the current (and any queued) cutscene videos.
+    pub fn skip_cutscene(&mut self) {
+        self.pending_videos.clear();
+        self.video_player = None;
+        self.audio.stop_all();
+    }
+
+    /// Advance cutscene playback by one 30fps tick.
+    fn cutscene_tick(&mut self) {
+        // Load the next queued video if none is playing.
+        if self.video_player.is_none() {
+            if self.pending_videos.is_empty() {
+                return;
+            }
+            let name = self.pending_videos.remove(0);
+            if !self.start_video(&name) {
+                // Could not start this one; the next tick tries the next entry
+                // (or finishes the cutscene and loads the SSL content).
+                return;
+            }
+        }
+
+        let (w, h) = (self.renderer.width as usize, self.renderer.height as usize);
+        if let Some(player) = self.video_player.as_mut() {
+            player.advance_and_render(1.0 / 30.0, &mut self.renderer.buffer, w, h);
+            if player.is_finished() {
+                self.video_player = None;
+                self.audio.stop_all();
+            }
+        }
+    }
+
+    /// Resolve, load and start a cutscene video. Returns false on any failure
+    /// (missing file, bad data) so the caller can fall through.
+    fn start_video(&mut self, name: &str) -> bool {
+        let path = match ContentLoader::find_content_file(&self.filename, name) {
+            Some(p) => p,
+            None => {
+                log::warn!("Cutscene video not found: {}", name);
+                return false;
+            }
+        };
+        log::info!("Playing cutscene: {}", path.display());
+
+        let data = match std::fs::read(&path) {
+            Ok(d) => d,
+            Err(e) => {
+                log::warn!("Failed to read cutscene {}: {}", path.display(), e);
+                return false;
+            }
+        };
+
+        let streams = crate::mpeg::demux_all(data);
+        if streams.video.is_empty() {
+            log::warn!("Cutscene has no video stream: {}", path.display());
+            return false;
+        }
+
+        // Decode and start the audio track up front (if present).
+        if !streams.audio.is_empty() {
+            let mut audio = crate::mpeg::Audio::new(streams.audio);
+            if audio.has_header() {
+                let rate = audio.samplerate();
+                let mut pcm: Vec<f32> = Vec::new();
+                while let Some(s) = audio.decode() {
+                    pcm.extend_from_slice(&s.interleaved);
+                }
+                self.audio.stop_all();
+                self.audio.play_pcm_stream(pcm, 2, rate);
+            }
+        }
+
+        match crate::mpeg::VideoPlayer::new(streams.video) {
+            Some(player) => {
+                self.video_player = Some(player);
+                true
+            }
+            None => {
+                log::warn!("Cutscene video has no sequence header: {}", path.display());
+                false
             }
         }
     }
@@ -263,6 +376,10 @@ impl Emulator {
 
     /// Draw the current frame to the renderer's buffer.
     pub fn draw(&mut self) {
+        // During a cutscene the framebuffer is produced by the video player.
+        if self.is_cutscene_active() {
+            return;
+        }
         self.renderer
             .draw_frame(&mut self.reader, &self.sprites, &self.cur_frame_objects);
     }
@@ -497,8 +614,11 @@ impl VmHost for Emulator {
             "SSL_PlayNext" => {
                 log::info!("SSL_PlayNext({}, {})", url, target);
                 let url_parts: Vec<&str> = url.split('+').collect();
-                for skipped in &url_parts[..url_parts.len().saturating_sub(1)] {
-                    log::info!("Ignoring SSL_PlayNext pre-content: {}", skipped);
+                // All parts except the last are MPEG-1 pre-content (logo /
+                // cutscene videos) to play before loading the final SSL content.
+                if url_parts.len() > 1 {
+                    let pre = &url_parts[..url_parts.len() - 1];
+                    self.queue_videos(pre);
                 }
                 if let Some(last) = url_parts.last() {
                     self.content_loader.queue_load(last);
@@ -582,4 +702,15 @@ fn str_to_float(s: &str) -> f64 {
         return 0.0;
     }
     s.parse::<f64>().unwrap_or(0.0)
+}
+
+/// Normalize a Native32 content path: split on '/', trim each component
+/// (games pad directory names with trailing spaces), drop empties, rejoin.
+fn normalize_content_path(filename: &str) -> String {
+    filename
+        .split('/')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("/")
 }

--- a/crates/native32emu-core/src/lib.rs
+++ b/crates/native32emu-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod frame_player;
 pub mod header_decryptor;
 pub mod image_decoder;
 pub mod input_handler;
+pub mod mpeg;
 pub mod renderer;
 pub mod save_manager;
 pub mod sprite_system;

--- a/crates/native32emu-core/src/mpeg/audio.rs
+++ b/crates/native32emu-core/src/mpeg/audio.rs
@@ -1,0 +1,872 @@
+// MPEG-1 Audio Layer II ("mp2") decoder.
+//
+// Ported to Rust from PL_MPEG (https://github.com/phoboslab/pl_mpeg) by Dominic
+// Szablewski, originally MIT licensed; itself based on kjmp2 by Martin J.
+// Fiedler. Decodes an MP2 elementary stream into normalized stereo float PCM.
+
+use super::buffer::Buffer;
+
+pub const SAMPLES_PER_FRAME: usize = 1152;
+
+const FRAME_SYNC: u32 = 0x7ff;
+
+const MPEG_1: u32 = 0x3;
+const LAYER_II: u32 = 0x2;
+
+const MODE_JOINT_STEREO: u32 = 0x1;
+const MODE_MONO: u32 = 0x3;
+
+const SAMPLE_RATE: [u32; 8] = [
+    44100, 48000, 32000, 0, // MPEG-1
+    22050, 24000, 16000, 0, // MPEG-2
+];
+
+const BIT_RATE: [i32; 28] = [
+    32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384, // MPEG-1
+    8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, // MPEG-2
+];
+
+const SCALEFACTOR_BASE: [i32; 3] = [0x0200_0000, 0x0196_5FEA, 0x0142_8A30];
+
+// Quantizer lookup, step 1: bitrate classes (mono / stereo).
+const QUANT_LUT_STEP_1: [[u8; 16]; 2] = [
+    [0, 0, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0],
+    [0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 2, 0, 0],
+];
+
+// Quantizer lookup, step 2: bitrate class, sample rate -> B2 table idx, sblimit.
+const QUANT_TAB_A: u8 = 27 | 64; // sblimit 27
+const QUANT_TAB_B: u8 = 30 | 64; // sblimit 30
+const QUANT_TAB_C: u8 = 8; // sblimit 8
+const QUANT_TAB_D: u8 = 12; // sblimit 12
+
+const QUANT_LUT_STEP_2: [[u8; 3]; 3] = [
+    [QUANT_TAB_C, QUANT_TAB_C, QUANT_TAB_D],
+    [QUANT_TAB_A, QUANT_TAB_A, QUANT_TAB_A],
+    [QUANT_TAB_B, QUANT_TAB_A, QUANT_TAB_B],
+];
+
+// Quantizer lookup, step 3: B2 table, subband -> nbal (upper 4 bits), row index
+// (lower 4 bits).
+const QUANT_LUT_STEP_3: [[u8; 32]; 3] = [
+    // Low-rate table.
+    [
+        0x44, 0x44, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ],
+    // High-rate table.
+    [
+        0x43, 0x43, 0x43, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x31, 0x31, 0x31, 0x31,
+        0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x31, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20, 0x20,
+        0, 0,
+    ],
+    // MPEG-2 LSR table (unused for MPEG-1 but kept for fidelity).
+    [
+        0x45, 0x45, 0x45, 0x45, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x34, 0x24, 0x24, 0x24, 0x24,
+        0x24, 0x24, 0x24, 0x24, 0x24, 0x24, 0x24, 0x24, 0x24, 0x24, 0x24, 0x24, 0x24, 0x24, 0x24,
+        0x24, 0,
+    ],
+];
+
+// Quantizer lookup, step 4: table row, allocation value -> quant table index.
+const QUANT_LUT_STEP_4: [[u8; 16]; 6] = [
+    [0, 1, 2, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 1, 2, 3, 4, 5, 6, 17, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 17],
+    [0, 1, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
+    [0, 1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 17],
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+];
+
+#[derive(Clone, Copy)]
+struct QuantSpec {
+    levels: u16,
+    group: u8,
+    bits: u8,
+}
+
+const QUANT_TAB: [QuantSpec; 17] = [
+    QuantSpec {
+        levels: 3,
+        group: 1,
+        bits: 5,
+    },
+    QuantSpec {
+        levels: 5,
+        group: 1,
+        bits: 7,
+    },
+    QuantSpec {
+        levels: 7,
+        group: 0,
+        bits: 3,
+    },
+    QuantSpec {
+        levels: 9,
+        group: 1,
+        bits: 10,
+    },
+    QuantSpec {
+        levels: 15,
+        group: 0,
+        bits: 4,
+    },
+    QuantSpec {
+        levels: 31,
+        group: 0,
+        bits: 5,
+    },
+    QuantSpec {
+        levels: 63,
+        group: 0,
+        bits: 6,
+    },
+    QuantSpec {
+        levels: 127,
+        group: 0,
+        bits: 7,
+    },
+    QuantSpec {
+        levels: 255,
+        group: 0,
+        bits: 8,
+    },
+    QuantSpec {
+        levels: 511,
+        group: 0,
+        bits: 9,
+    },
+    QuantSpec {
+        levels: 1023,
+        group: 0,
+        bits: 10,
+    },
+    QuantSpec {
+        levels: 2047,
+        group: 0,
+        bits: 11,
+    },
+    QuantSpec {
+        levels: 4095,
+        group: 0,
+        bits: 12,
+    },
+    QuantSpec {
+        levels: 8191,
+        group: 0,
+        bits: 13,
+    },
+    QuantSpec {
+        levels: 16383,
+        group: 0,
+        bits: 14,
+    },
+    QuantSpec {
+        levels: 32767,
+        group: 0,
+        bits: 15,
+    },
+    QuantSpec {
+        levels: 65535,
+        group: 0,
+        bits: 16,
+    },
+];
+
+const SYNTHESIS_WINDOW: [f32; 512] = [
+    0.0, -0.5, -0.5, -0.5, -0.5, -0.5, -0.5, -1.0, -1.0, -1.0, -1.0, -1.5, -1.5, -2.0, -2.0, -2.5,
+    -2.5, -3.0, -3.5, -3.5, -4.0, -4.5, -5.0, -5.5, -6.5, -7.0, -8.0, -8.5, -9.5, -10.5, -12.0,
+    -13.0, -14.5, -15.5, -17.5, -19.0, -20.5, -22.5, -24.5, -26.5, -29.0, -31.5, -34.0, -36.5,
+    -39.5, -42.5, -45.5, -48.5, -52.0, -55.5, -58.5, -62.5, -66.0, -69.5, -73.5, -77.0, -80.5,
+    -84.5, -88.0, -91.5, -95.0, -98.0, -101.0, -104.0, 106.5, 109.0, 111.0, 112.5, 113.5, 114.0,
+    114.0, 113.5, 112.0, 110.5, 107.5, 104.0, 100.0, 94.5, 88.5, 81.5, 73.0, 63.5, 53.0, 41.5,
+    28.5, 14.5, -1.0, -18.0, -36.0, -55.5, -76.5, -98.5, -122.0, -147.0, -173.5, -200.5, -229.5,
+    -259.5, -290.5, -322.5, -355.5, -389.5, -424.0, -459.5, -495.5, -532.0, -568.5, -605.0, -641.5,
+    -678.0, -714.0, -749.0, -783.5, -817.0, -849.0, -879.5, -908.5, -935.0, -959.5, -981.0,
+    -1000.5, -1016.0, -1028.5, -1037.5, -1042.5, -1043.5, -1040.0, -1031.5, 1018.5, 1000.0, 976.0,
+    946.5, 911.0, 869.5, 822.0, 767.5, 707.0, 640.0, 565.5, 485.0, 397.0, 302.5, 201.0, 92.5,
+    -22.5, -144.0, -272.5, -407.0, -547.5, -694.0, -846.0, -1003.0, -1165.0, -1331.5, -1502.0,
+    -1675.5, -1852.5, -2031.5, -2212.5, -2394.0, -2576.5, -2758.5, -2939.5, -3118.5, -3294.5,
+    -3467.5, -3635.5, -3798.5, -3955.0, -4104.5, -4245.5, -4377.5, -4499.0, -4609.5, -4708.0,
+    -4792.5, -4863.5, -4919.0, -4958.0, -4979.5, -4983.0, -4967.5, -4931.5, -4875.0, -4796.0,
+    -4694.5, -4569.5, -4420.0, -4246.0, -4046.0, -3820.0, -3567.0, 3287.0, 2979.5, 2644.0, 2280.5,
+    1888.0, 1467.5, 1018.5, 541.0, 35.0, -499.0, -1061.0, -1650.0, -2266.5, -2909.0, -3577.0,
+    -4270.0, -4987.5, -5727.5, -6490.0, -7274.0, -8077.5, -8899.5, -9739.0, -10594.5, -11464.5,
+    -12347.0, -13241.0, -14144.5, -15056.0, -15973.5, -16895.5, -17820.0, -18744.5, -19668.0,
+    -20588.0, -21503.0, -22410.5, -23308.5, -24195.0, -25068.5, -25926.5, -26767.0, -27589.0,
+    -28389.0, -29166.5, -29919.0, -30644.5, -31342.0, -32009.5, -32645.0, -33247.0, -33814.5,
+    -34346.0, -34839.5, -35295.0, -35710.0, -36084.5, -36417.5, -36707.5, -36954.0, -37156.5,
+    -37315.0, -37428.0, -37496.0, 37519.0, 37496.0, 37428.0, 37315.0, 37156.5, 36954.0, 36707.5,
+    36417.5, 36084.5, 35710.0, 35295.0, 34839.5, 34346.0, 33814.5, 33247.0, 32645.0, 32009.5,
+    31342.0, 30644.5, 29919.0, 29166.5, 28389.0, 27589.0, 26767.0, 25926.5, 25068.5, 24195.0,
+    23308.5, 22410.5, 21503.0, 20588.0, 19668.0, 18744.5, 17820.0, 16895.5, 15973.5, 15056.0,
+    14144.5, 13241.0, 12347.0, 11464.5, 10594.5, 9739.0, 8899.5, 8077.5, 7274.0, 6490.0, 5727.5,
+    4987.5, 4270.0, 3577.0, 2909.0, 2266.5, 1650.0, 1061.0, 499.0, -35.0, -541.0, -1018.5, -1467.5,
+    -1888.0, -2280.5, -2644.0, -2979.5, 3287.0, 3567.0, 3820.0, 4046.0, 4246.0, 4420.0, 4569.5,
+    4694.5, 4796.0, 4875.0, 4931.5, 4967.5, 4983.0, 4979.5, 4958.0, 4919.0, 4863.5, 4792.5, 4708.0,
+    4609.5, 4499.0, 4377.5, 4245.5, 4104.5, 3955.0, 3798.5, 3635.5, 3467.5, 3294.5, 3118.5, 2939.5,
+    2758.5, 2576.5, 2394.0, 2212.5, 2031.5, 1852.5, 1675.5, 1502.0, 1331.5, 1165.0, 1003.0, 846.0,
+    694.0, 547.5, 407.0, 272.5, 144.0, 22.5, -92.5, -201.0, -302.5, -397.0, -485.0, -565.5, -640.0,
+    -707.0, -767.5, -822.0, -869.5, -911.0, -946.5, -976.0, -1000.0, 1018.5, 1031.5, 1040.0,
+    1043.5, 1042.5, 1037.5, 1028.5, 1016.0, 1000.5, 981.0, 959.5, 935.0, 908.5, 879.5, 849.0,
+    817.0, 783.5, 749.0, 714.0, 678.0, 641.5, 605.0, 568.5, 532.0, 495.5, 459.5, 424.0, 389.5,
+    355.5, 322.5, 290.5, 259.5, 229.5, 200.5, 173.5, 147.0, 122.0, 98.5, 76.5, 55.5, 36.0, 18.0,
+    1.0, -14.5, -28.5, -41.5, -53.0, -63.5, -73.0, -81.5, -88.5, -94.5, -100.0, -104.0, -107.5,
+    -110.5, -112.0, -113.5, -114.0, -114.0, -113.5, -112.5, -111.0, -109.0, 106.5, 104.0, 101.0,
+    98.0, 95.0, 91.5, 88.0, 84.5, 80.5, 77.0, 73.5, 69.5, 66.0, 62.5, 58.5, 55.5, 52.0, 48.5, 45.5,
+    42.5, 39.5, 36.5, 34.0, 31.5, 29.0, 26.5, 24.5, 22.5, 20.5, 19.0, 17.5, 15.5, 14.5, 13.0, 12.0,
+    10.5, 9.5, 8.5, 8.0, 7.0, 6.5, 5.5, 5.0, 4.5, 4.0, 3.5, 3.5, 3.0, 2.5, 2.5, 2.0, 2.0, 1.5, 1.5,
+    1.0, 1.0, 1.0, 1.0, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
+];
+
+/// A decoded MP2 frame: 1152 normalized stereo samples, interleaved L/R.
+pub struct Samples {
+    pub time: f64,
+    pub interleaved: Vec<f32>,
+}
+
+/// MP2 audio decoder over an in-memory elementary stream.
+pub struct Audio {
+    buffer: Buffer,
+    time: f64,
+    samples_decoded: i64,
+    samplerate_index: usize,
+    bitrate_index: usize,
+    version: u32,
+    layer: u32,
+    mode: u32,
+    bound: usize,
+    v_pos: i32,
+    next_frame_data_size: usize,
+    has_header: bool,
+
+    allocation: [[Option<&'static QuantSpec>; 32]; 2],
+    scale_factor_info: [[u8; 32]; 2],
+    scale_factor: [[[i32; 3]; 32]; 2],
+    sample: [[[i32; 3]; 32]; 2],
+
+    interleaved: Vec<f32>,
+    d: Vec<f32>,
+    v: [Vec<f32>; 2],
+    u: [f32; 32],
+}
+
+impl Audio {
+    pub fn new(audio_es: Vec<u8>) -> Self {
+        let mut d = vec![0.0f32; 1024];
+        d[..512].copy_from_slice(&SYNTHESIS_WINDOW);
+        d[512..].copy_from_slice(&SYNTHESIS_WINDOW);
+
+        let mut s = Self {
+            buffer: Buffer::new(audio_es),
+            time: 0.0,
+            samples_decoded: 0,
+            samplerate_index: 3, // indicates 0
+            bitrate_index: 0,
+            version: 0,
+            layer: 0,
+            mode: 0,
+            bound: 0,
+            v_pos: 0,
+            next_frame_data_size: 0,
+            has_header: false,
+            allocation: [[None; 32]; 2],
+            scale_factor_info: [[0; 32]; 2],
+            scale_factor: [[[0; 3]; 32]; 2],
+            sample: [[[0; 3]; 32]; 2],
+            interleaved: vec![0.0; SAMPLES_PER_FRAME * 2],
+            d,
+            v: [vec![0.0; 1024], vec![0.0; 1024]],
+            u: [0.0; 32],
+        };
+        s.next_frame_data_size = s.decode_header();
+        s
+    }
+
+    pub fn has_header(&mut self) -> bool {
+        if self.has_header {
+            return true;
+        }
+        self.next_frame_data_size = self.decode_header();
+        self.has_header
+    }
+
+    pub fn samplerate(&self) -> u32 {
+        if self.has_header {
+            SAMPLE_RATE[self.samplerate_index]
+        } else {
+            0
+        }
+    }
+
+    /// Decode the next MP2 frame, or `None` at end of stream.
+    pub fn decode(&mut self) -> Option<Samples> {
+        if self.next_frame_data_size == 0 {
+            if !self.buffer.has(48) {
+                return None;
+            }
+            self.next_frame_data_size = self.decode_header();
+        }
+        if self.next_frame_data_size == 0 || !self.buffer.has(self.next_frame_data_size << 3) {
+            return None;
+        }
+
+        self.decode_frame();
+        self.next_frame_data_size = 0;
+
+        let time = self.time;
+        self.samples_decoded += SAMPLES_PER_FRAME as i64;
+        self.time = self.samples_decoded as f64 / SAMPLE_RATE[self.samplerate_index] as f64;
+
+        Some(Samples {
+            time,
+            interleaved: self.interleaved.clone(),
+        })
+    }
+
+    fn decode_header(&mut self) -> usize {
+        if !self.buffer.has(48) {
+            return 0;
+        }
+        self.buffer.skip_bytes(0x00);
+        let sync = self.buffer.read(11);
+
+        if sync != FRAME_SYNC && !self.buffer.find_frame_sync() {
+            return 0;
+        }
+
+        self.version = self.buffer.read(2);
+        self.layer = self.buffer.read(2);
+        let has_crc = self.buffer.read(1) == 0;
+
+        if self.version != MPEG_1 || self.layer != LAYER_II {
+            return 0;
+        }
+
+        let bitrate_index = self.buffer.read(4) as i32 - 1;
+        if !(0..=13).contains(&bitrate_index) {
+            return 0;
+        }
+        let bitrate_index = bitrate_index as usize;
+
+        let samplerate_index = self.buffer.read(2) as usize;
+        if samplerate_index == 3 {
+            return 0;
+        }
+
+        let padding = self.buffer.read(1) as usize;
+        self.buffer.skip(1); // f_private
+        let mode = self.buffer.read(2);
+
+        // If we already have a header, the format must match or we lost sync.
+        if self.has_header
+            && (self.bitrate_index != bitrate_index
+                || self.samplerate_index != samplerate_index
+                || self.mode != mode)
+        {
+            return 0;
+        }
+
+        self.bitrate_index = bitrate_index;
+        self.samplerate_index = samplerate_index;
+        self.mode = mode;
+        self.has_header = true;
+
+        if mode == MODE_JOINT_STEREO {
+            self.bound = ((self.buffer.read(2) + 1) << 2) as usize;
+        } else {
+            self.buffer.skip(2);
+            self.bound = if mode == MODE_MONO { 0 } else { 32 };
+        }
+
+        // Discard copyright/original/emphasis and the optional CRC.
+        self.buffer.skip(4);
+        if has_crc {
+            self.buffer.skip(16);
+        }
+
+        let bitrate = BIT_RATE[self.bitrate_index];
+        let samplerate = SAMPLE_RATE[self.samplerate_index] as i32;
+        let frame_size = (144000 * bitrate / samplerate) as usize + padding;
+        frame_size - if has_crc { 6 } else { 4 }
+    }
+
+    fn read_allocation(&mut self, sb: usize, tab3: usize) -> Option<&'static QuantSpec> {
+        let tab4 = QUANT_LUT_STEP_3[tab3][sb];
+        let nbal = (tab4 >> 4) as usize;
+        let row = (tab4 & 15) as usize;
+        let qtab = QUANT_LUT_STEP_4[row][self.buffer.read(nbal) as usize];
+        if qtab != 0 {
+            Some(&QUANT_TAB[(qtab - 1) as usize])
+        } else {
+            None
+        }
+    }
+
+    fn read_samples(&mut self, ch: usize, sb: usize, part: usize) {
+        let q = match self.allocation[ch][sb] {
+            Some(q) => q,
+            None => {
+                self.sample[ch][sb] = [0; 3];
+                return;
+            }
+        };
+
+        // Resolve scalefactor.
+        let mut sf = self.scale_factor[ch][sb][part];
+        if sf == 63 {
+            sf = 0;
+        } else {
+            let shift = sf / 3;
+            sf = (SCALEFACTOR_BASE[(sf % 3) as usize] + ((1 << shift) >> 1)) >> shift;
+        }
+
+        // Decode samples.
+        let mut adj = q.levels as i32;
+        if q.group != 0 {
+            let mut val = self.buffer.read(q.bits as usize) as i32;
+            self.sample[ch][sb][0] = val % adj;
+            val /= adj;
+            self.sample[ch][sb][1] = val % adj;
+            self.sample[ch][sb][2] = val / adj;
+        } else {
+            for i in 0..3 {
+                self.sample[ch][sb][i] = self.buffer.read(q.bits as usize) as i32;
+            }
+        }
+
+        // Postmultiply samples.
+        let scale = 65536 / (adj + 1);
+        adj = ((adj + 1) >> 1) - 1;
+        for i in 0..3 {
+            let val = (adj - self.sample[ch][sb][i]) * scale;
+            self.sample[ch][sb][i] = (val * (sf >> 12) + ((val * (sf & 4095) + 2048) >> 12)) >> 12;
+        }
+    }
+
+    fn decode_frame(&mut self) {
+        let tab1 = if self.mode == MODE_MONO { 0 } else { 1 };
+        let tab2 = QUANT_LUT_STEP_1[tab1][self.bitrate_index] as usize;
+        let mut tab3 = QUANT_LUT_STEP_2[tab2][self.samplerate_index] as usize;
+        let sblimit = tab3 & 63;
+        tab3 >>= 6;
+
+        if self.bound > sblimit {
+            self.bound = sblimit;
+        }
+        let bound = self.bound;
+
+        // Allocation information.
+        for sb in 0..bound {
+            self.allocation[0][sb] = self.read_allocation(sb, tab3);
+            self.allocation[1][sb] = self.read_allocation(sb, tab3);
+        }
+        for sb in bound..sblimit {
+            let a = self.read_allocation(sb, tab3);
+            self.allocation[0][sb] = a;
+            self.allocation[1][sb] = a;
+        }
+
+        // Scale factor selector information.
+        let channels = if self.mode == MODE_MONO { 1 } else { 2 };
+        for sb in 0..sblimit {
+            for ch in 0..channels {
+                if self.allocation[ch][sb].is_some() {
+                    self.scale_factor_info[ch][sb] = self.buffer.read(2) as u8;
+                }
+            }
+            if self.mode == MODE_MONO {
+                self.scale_factor_info[1][sb] = self.scale_factor_info[0][sb];
+            }
+        }
+
+        // Scale factors.
+        for sb in 0..sblimit {
+            for ch in 0..channels {
+                if self.allocation[ch][sb].is_some() {
+                    let info = self.scale_factor_info[ch][sb];
+                    let sf = &mut self.scale_factor[ch][sb];
+                    match info {
+                        0 => {
+                            sf[0] = self.buffer.read(6) as i32;
+                            sf[1] = self.buffer.read(6) as i32;
+                            sf[2] = self.buffer.read(6) as i32;
+                        }
+                        1 => {
+                            let a = self.buffer.read(6) as i32;
+                            sf[0] = a;
+                            sf[1] = a;
+                            sf[2] = self.buffer.read(6) as i32;
+                        }
+                        2 => {
+                            let a = self.buffer.read(6) as i32;
+                            sf[0] = a;
+                            sf[1] = a;
+                            sf[2] = a;
+                        }
+                        _ => {
+                            sf[0] = self.buffer.read(6) as i32;
+                            let a = self.buffer.read(6) as i32;
+                            sf[1] = a;
+                            sf[2] = a;
+                        }
+                    }
+                }
+            }
+            if self.mode == MODE_MONO {
+                self.scale_factor[1][sb] = self.scale_factor[0][sb];
+            }
+        }
+
+        // Coefficient input and reconstruction.
+        let mut out_pos = 0usize;
+        for part in 0..3 {
+            for _granule in 0..4 {
+                for sb in 0..bound {
+                    self.read_samples(0, sb, part);
+                    self.read_samples(1, sb, part);
+                }
+                for sb in bound..sblimit {
+                    self.read_samples(0, sb, part);
+                    self.sample[1][sb] = self.sample[0][sb];
+                }
+                for sb in sblimit..32 {
+                    self.sample[0][sb] = [0; 3];
+                    self.sample[1][sb] = [0; 3];
+                }
+
+                // Synthesis.
+                for p in 0..3 {
+                    self.v_pos = (self.v_pos - 64) & 1023;
+
+                    for ch in 0..2 {
+                        idct36(&self.sample[ch], p, &mut self.v[ch], self.v_pos as usize);
+
+                        self.u = [0.0; 32];
+                        let mut d_index = 512 - (self.v_pos >> 1);
+                        let mut v_index = (self.v_pos % 128) >> 1;
+                        while v_index < 1024 {
+                            for i in 0..32 {
+                                self.u[i] +=
+                                    self.d[d_index as usize] * self.v[ch][v_index as usize];
+                                d_index += 1;
+                                v_index += 1;
+                            }
+                            v_index += 128 - 32;
+                            d_index += 64 - 32;
+                        }
+
+                        d_index -= 512 - 32;
+                        v_index = (128 - 32 + 1024) - v_index;
+                        while v_index < 1024 {
+                            for i in 0..32 {
+                                self.u[i] +=
+                                    self.d[d_index as usize] * self.v[ch][v_index as usize];
+                                d_index += 1;
+                                v_index += 1;
+                            }
+                            v_index += 128 - 32;
+                            d_index += 64 - 32;
+                        }
+
+                        for j in 0..32 {
+                            self.interleaved[((out_pos + j) << 1) + ch] =
+                                self.u[j] / -1_090_519_040.0f32;
+                        }
+                    }
+                    out_pos += 32;
+                }
+            }
+        }
+
+        self.buffer.align();
+    }
+}
+
+#[allow(clippy::needless_range_loop)]
+#[allow(clippy::excessive_precision)]
+#[allow(clippy::approx_constant)]
+fn idct36(s: &[[i32; 3]; 32], ss: usize, d: &mut [f32], dp: usize) {
+    let g = |i: usize| s[i][ss] as f32;
+
+    let mut t01 = g(0) + g(31);
+    let mut t02 = (g(0) - g(31)) * 0.500602998235;
+    let mut t03 = g(1) + g(30);
+    let mut t04 = (g(1) - g(30)) * 0.505470959898;
+    let mut t05 = g(2) + g(29);
+    let mut t06 = (g(2) - g(29)) * 0.515447309923;
+    let mut t07 = g(3) + g(28);
+    let mut t08 = (g(3) - g(28)) * 0.53104259109;
+    let mut t09 = g(4) + g(27);
+    let mut t10 = (g(4) - g(27)) * 0.553103896034;
+    let mut t11 = g(5) + g(26);
+    let mut t12 = (g(5) - g(26)) * 0.582934968206;
+    let mut t13 = g(6) + g(25);
+    let mut t14 = (g(6) - g(25)) * 0.622504123036;
+    let mut t15 = g(7) + g(24);
+    let mut t16 = (g(7) - g(24)) * 0.674808341455;
+    let mut t17 = g(8) + g(23);
+    let mut t18 = (g(8) - g(23)) * 0.744536271002;
+    let mut t19 = g(9) + g(22);
+    let mut t20 = (g(9) - g(22)) * 0.839349645416;
+    let mut t21 = g(10) + g(21);
+    let mut t22 = (g(10) - g(21)) * 0.972568237862;
+    let mut t23 = g(11) + g(20);
+    let mut t24 = (g(11) - g(20)) * 1.16943993343;
+    let mut t25 = g(12) + g(19);
+    let mut t26 = (g(12) - g(19)) * 1.48416461631;
+    let mut t27 = g(13) + g(18);
+    let mut t28 = (g(13) - g(18)) * 2.05778100995;
+    let mut t29 = g(14) + g(17);
+    let mut t30 = (g(14) - g(17)) * 3.40760841847;
+    let mut t31 = g(15) + g(16);
+    let mut t32 = (g(15) - g(16)) * 10.1900081235;
+
+    let mut t33;
+
+    t33 = t01 + t31;
+    t31 = (t01 - t31) * 0.502419286188;
+    t01 = t03 + t29;
+    t29 = (t03 - t29) * 0.52249861494;
+    t03 = t05 + t27;
+    t27 = (t05 - t27) * 0.566944034816;
+    t05 = t07 + t25;
+    t25 = (t07 - t25) * 0.64682178336;
+    t07 = t09 + t23;
+    t23 = (t09 - t23) * 0.788154623451;
+    t09 = t11 + t21;
+    t21 = (t11 - t21) * 1.06067768599;
+    t11 = t13 + t19;
+    t19 = (t13 - t19) * 1.72244709824;
+    t13 = t15 + t17;
+    t17 = (t15 - t17) * 5.10114861869;
+
+    t15 = t33 + t13;
+    t13 = (t33 - t13) * 0.509795579104;
+    t33 = t01 + t11;
+    t01 = (t01 - t11) * 0.601344886935;
+    t11 = t03 + t09;
+    t09 = (t03 - t09) * 0.899976223136;
+    t03 = t05 + t07;
+    t07 = (t05 - t07) * 2.56291544774;
+    t05 = t15 + t03;
+    t15 = (t15 - t03) * 0.541196100146;
+    t03 = t33 + t11;
+    t11 = (t33 - t11) * 1.30656296488;
+    t33 = t05 + t03;
+    t05 = (t05 - t03) * 0.707106781187;
+    t03 = t15 + t11;
+    t15 = (t15 - t11) * 0.707106781187;
+    t03 += t15;
+    t11 = t13 + t07;
+    t13 = (t13 - t07) * 0.541196100146;
+    t07 = t01 + t09;
+    t09 = (t01 - t09) * 1.30656296488;
+    t01 = t11 + t07;
+    t07 = (t11 - t07) * 0.707106781187;
+    t11 = t13 + t09;
+    t13 = (t13 - t09) * 0.707106781187;
+    t11 += t13;
+    t01 += t11;
+    t11 += t07;
+    t07 += t13;
+    t09 = t31 + t17;
+    t31 = (t31 - t17) * 0.509795579104;
+    t17 = t29 + t19;
+    t29 = (t29 - t19) * 0.601344886935;
+    t19 = t27 + t21;
+    t21 = (t27 - t21) * 0.899976223136;
+    t27 = t25 + t23;
+    t23 = (t25 - t23) * 2.56291544774;
+    t25 = t09 + t27;
+    t09 = (t09 - t27) * 0.541196100146;
+    t27 = t17 + t19;
+    t19 = (t17 - t19) * 1.30656296488;
+    t17 = t25 + t27;
+    t27 = (t25 - t27) * 0.707106781187;
+    t25 = t09 + t19;
+    t19 = (t09 - t19) * 0.707106781187;
+    t25 += t19;
+    t09 = t31 + t23;
+    t31 = (t31 - t23) * 0.541196100146;
+    t23 = t29 + t21;
+    t21 = (t29 - t21) * 1.30656296488;
+    t29 = t09 + t23;
+    t23 = (t09 - t23) * 0.707106781187;
+    t09 = t31 + t21;
+    t31 = (t31 - t21) * 0.707106781187;
+    t09 += t31;
+    t29 += t09;
+    t09 += t23;
+    t23 += t31;
+    t17 += t29;
+    t29 += t25;
+    t25 += t09;
+    t09 += t27;
+    t27 += t23;
+    t23 += t19;
+    t19 += t31;
+
+    t21 = t02 + t32;
+    t02 = (t02 - t32) * 0.500602998235;
+    t32 = t04 + t30;
+    t04 = (t04 - t30) * 0.52249861494;
+    t30 = t06 + t28;
+    t28 = (t06 - t28) * 0.566944034816;
+    t06 = t08 + t26;
+    t08 = (t08 - t26) * 0.64682178336;
+    t26 = t10 + t24;
+    t10 = (t10 - t24) * 0.788154623451;
+    t24 = t12 + t22;
+    t22 = (t12 - t22) * 1.06067768599;
+    t12 = t14 + t20;
+    t20 = (t14 - t20) * 1.72244709824;
+    t14 = t16 + t18;
+    t16 = (t16 - t18) * 5.10114861869;
+
+    t18 = t21 + t14;
+    t14 = (t21 - t14) * 0.509795579104;
+    t21 = t32 + t12;
+    t32 = (t32 - t12) * 0.601344886935;
+    t12 = t30 + t24;
+    t24 = (t30 - t24) * 0.899976223136;
+    t30 = t06 + t26;
+    t26 = (t06 - t26) * 2.56291544774;
+    t06 = t18 + t30;
+    t18 = (t18 - t30) * 0.541196100146;
+    t30 = t21 + t12;
+    t12 = (t21 - t12) * 1.30656296488;
+    t21 = t06 + t30;
+    t30 = (t06 - t30) * 0.707106781187;
+    t06 = t18 + t12;
+    t12 = (t18 - t12) * 0.707106781187;
+    t06 += t12;
+    t18 = t14 + t26;
+    t26 = (t14 - t26) * 0.541196100146;
+    t14 = t32 + t24;
+    t24 = (t32 - t24) * 1.30656296488;
+    t32 = t18 + t14;
+    t14 = (t18 - t14) * 0.707106781187;
+    t18 = t26 + t24;
+    t24 = (t26 - t24) * 0.707106781187;
+    t18 += t24;
+    t32 += t18;
+    t18 += t14;
+    t26 = t14 + t24;
+    t14 = t02 + t16;
+    t02 = (t02 - t16) * 0.509795579104;
+    t16 = t04 + t20;
+    t04 = (t04 - t20) * 0.601344886935;
+    t20 = t28 + t22;
+    t22 = (t28 - t22) * 0.899976223136;
+    t28 = t08 + t10;
+    t10 = (t08 - t10) * 2.56291544774;
+    t08 = t14 + t28;
+    t14 = (t14 - t28) * 0.541196100146;
+    t28 = t16 + t20;
+    t20 = (t16 - t20) * 1.30656296488;
+    t16 = t08 + t28;
+    t28 = (t08 - t28) * 0.707106781187;
+    t08 = t14 + t20;
+    t20 = (t14 - t20) * 0.707106781187;
+    t08 += t20;
+    t14 = t02 + t10;
+    t02 = (t02 - t10) * 0.541196100146;
+    t10 = t04 + t22;
+    t22 = (t04 - t22) * 1.30656296488;
+    t04 = t14 + t10;
+    t10 = (t14 - t10) * 0.707106781187;
+    t14 = t02 + t22;
+    t02 = (t02 - t22) * 0.707106781187;
+    t14 += t02;
+    t04 += t14;
+    t14 += t10;
+    t10 += t02;
+    t16 += t04;
+    t04 += t08;
+    t08 += t14;
+    t14 += t28;
+    t28 += t10;
+    t10 += t20;
+    t20 += t02;
+    t21 += t16;
+    t16 += t32;
+    t32 += t04;
+    t04 += t06;
+    t06 += t08;
+    t08 += t18;
+    t18 += t14;
+    t14 += t30;
+    t30 += t28;
+    t28 += t26;
+    t26 += t10;
+    t10 += t12;
+    t12 += t20;
+    t20 += t24;
+    t24 += t02;
+
+    d[dp + 48] = -t33;
+    d[dp + 49] = -t21;
+    d[dp + 47] = -t21;
+    d[dp + 50] = -t17;
+    d[dp + 46] = -t17;
+    d[dp + 51] = -t16;
+    d[dp + 45] = -t16;
+    d[dp + 52] = -t01;
+    d[dp + 44] = -t01;
+    d[dp + 53] = -t32;
+    d[dp + 43] = -t32;
+    d[dp + 54] = -t29;
+    d[dp + 42] = -t29;
+    d[dp + 55] = -t04;
+    d[dp + 41] = -t04;
+    d[dp + 56] = -t03;
+    d[dp + 40] = -t03;
+    d[dp + 57] = -t06;
+    d[dp + 39] = -t06;
+    d[dp + 58] = -t25;
+    d[dp + 38] = -t25;
+    d[dp + 59] = -t08;
+    d[dp + 37] = -t08;
+    d[dp + 60] = -t11;
+    d[dp + 36] = -t11;
+    d[dp + 61] = -t18;
+    d[dp + 35] = -t18;
+    d[dp + 62] = -t09;
+    d[dp + 34] = -t09;
+    d[dp + 63] = -t14;
+    d[dp + 33] = -t14;
+    d[dp + 32] = -t05;
+    d[dp] = t05;
+    d[dp + 31] = -t30;
+    d[dp + 1] = t30;
+    d[dp + 30] = -t27;
+    d[dp + 2] = t27;
+    d[dp + 29] = -t28;
+    d[dp + 3] = t28;
+    d[dp + 28] = -t07;
+    d[dp + 4] = t07;
+    d[dp + 27] = -t26;
+    d[dp + 5] = t26;
+    d[dp + 26] = -t23;
+    d[dp + 6] = t23;
+    d[dp + 25] = -t10;
+    d[dp + 7] = t10;
+    d[dp + 24] = -t15;
+    d[dp + 8] = t15;
+    d[dp + 23] = -t12;
+    d[dp + 9] = t12;
+    d[dp + 22] = -t19;
+    d[dp + 10] = t19;
+    d[dp + 21] = -t20;
+    d[dp + 11] = t20;
+    d[dp + 20] = -t13;
+    d[dp + 12] = t13;
+    d[dp + 19] = -t24;
+    d[dp + 13] = t24;
+    d[dp + 18] = -t31;
+    d[dp + 14] = t31;
+    d[dp + 17] = -t02;
+    d[dp + 15] = t02;
+    d[dp + 16] = 0.0;
+}

--- a/crates/native32emu-core/src/mpeg/buffer.rs
+++ b/crates/native32emu-core/src/mpeg/buffer.rs
@@ -5,21 +5,6 @@
 // the whole stream is held in a single buffer, so there is no ring buffer,
 // load callbacks or partial-data handling.
 
-/// VLC decode table entry. `index` > 0 points to the next node; `index` <= 0
-/// terminates and `value` is the decoded symbol.
-#[derive(Clone, Copy)]
-pub struct Vlc {
-    pub index: i16,
-    pub value: i16,
-}
-
-/// VLC decode table entry with an unsigned value.
-#[derive(Clone, Copy)]
-pub struct VlcUint {
-    pub index: i16,
-    pub value: u16,
-}
-
 /// A bit reader over an owned byte buffer.
 pub struct Buffer {
     bytes: Vec<u8>,
@@ -148,32 +133,47 @@ impl Buffer {
         self.bytes.get(start..start + count)
     }
 
-    /// Decode a value using a binary VLC table (PL_MPEG layout).
-    pub fn read_vlc(&mut self, table: &[Vlc]) -> i16 {
-        let mut state = Vlc { index: 0, value: 0 };
+    /// Decode a value using a binary VLC table (PL_MPEG layout). Each entry is
+    /// `(index, value)`; a positive `index` points to the next node (`index +
+    /// bit`), `index <= 0` terminates with `value`.
+    pub fn read_vlc(&mut self, table: &[(i16, i16)]) -> i16 {
+        let mut index: i16 = 0;
         loop {
             let bit = self.read(1) as i16;
-            state = table[(state.index + bit) as usize];
-            if state.index <= 0 {
-                break;
+            let (next, value) = table[(index + bit) as usize];
+            if next <= 0 {
+                return value;
             }
+            index = next;
         }
-        state.value
     }
 
     /// Decode a value using an unsigned binary VLC table.
-    pub fn read_vlc_uint(&mut self, table: &[VlcUint]) -> u16 {
-        let mut state = VlcUint { index: 0, value: 0 };
+    pub fn read_vlc_uint(&mut self, table: &[(i16, u16)]) -> u16 {
+        let mut index: i16 = 0;
         loop {
             let bit = self.read(1) as i16;
-            let e = table[(state.index + bit) as usize];
-            state = e;
-            if state.index <= 0 {
-                break;
+            let (next, value) = table[(index + bit) as usize];
+            if next <= 0 {
+                return value;
             }
+            index = next;
         }
-        state.value
     }
+
+    /// Peek `bit_count` bits without consuming them; return whether non-zero.
+    pub fn peek_non_zero(&mut self, bit_count: usize) -> bool {
+        if !self.has(bit_count) {
+            return false;
+        }
+        let saved = self.bit_index;
+        let val = self.read(bit_count);
+        self.bit_index = saved;
+        val != 0
+    }
+
+    /// No-op for the in-memory buffer (kept for PL_MPEG API parity).
+    pub fn discard_read_bytes(&mut self) {}
 }
 
 #[cfg(test)]

--- a/crates/native32emu-core/src/mpeg/buffer.rs
+++ b/crates/native32emu-core/src/mpeg/buffer.rs
@@ -174,6 +174,24 @@ impl Buffer {
 
     /// No-op for the in-memory buffer (kept for PL_MPEG API parity).
     pub fn discard_read_bytes(&mut self) {}
+
+    /// Scan for an MP2 frame sync word (0xFF followed by a byte whose top 7
+    /// bits are set: `(b & 0xFE) == 0xFC`). On success positions the read head
+    /// just past the 11-bit sync and returns true; otherwise advances to the
+    /// end and returns false. Mirrors PL_MPEG's `plm_audio_find_frame_sync`.
+    pub fn find_frame_sync(&mut self) -> bool {
+        let mut i = self.bit_index >> 3;
+        let last = self.bytes.len().saturating_sub(1);
+        while i < last {
+            if self.bytes[i] == 0xFF && (self.bytes[i + 1] & 0xFE) == 0xFC {
+                self.bit_index = ((i + 1) << 3) + 3;
+                return true;
+            }
+            i += 1;
+        }
+        self.bit_index = (i + 1) << 3;
+        false
+    }
 }
 
 #[cfg(test)]

--- a/crates/native32emu-core/src/mpeg/buffer.rs
+++ b/crates/native32emu-core/src/mpeg/buffer.rs
@@ -1,0 +1,252 @@
+// MSB-first bit reader for MPEG streams.
+//
+// Ported to Rust from PL_MPEG (https://github.com/phoboslab/pl_mpeg) by
+// Dominic Szablewski, originally MIT licensed. This is the in-memory variant:
+// the whole stream is held in a single buffer, so there is no ring buffer,
+// load callbacks or partial-data handling.
+
+/// VLC decode table entry. `index` > 0 points to the next node; `index` <= 0
+/// terminates and `value` is the decoded symbol.
+#[derive(Clone, Copy)]
+pub struct Vlc {
+    pub index: i16,
+    pub value: i16,
+}
+
+/// VLC decode table entry with an unsigned value.
+#[derive(Clone, Copy)]
+pub struct VlcUint {
+    pub index: i16,
+    pub value: u16,
+}
+
+/// A bit reader over an owned byte buffer.
+pub struct Buffer {
+    bytes: Vec<u8>,
+    /// Current read position, in bits.
+    bit_index: usize,
+}
+
+impl Buffer {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self {
+            bytes,
+            bit_index: 0,
+        }
+    }
+
+    /// Total length of the buffer in bits.
+    fn len_bits(&self) -> usize {
+        self.bytes.len() << 3
+    }
+
+    /// Whether at least `count` more bits are available.
+    pub fn has(&self, count: usize) -> bool {
+        self.len_bits().saturating_sub(self.bit_index) >= count
+    }
+
+    /// Whether all bits have been consumed.
+    pub fn has_ended(&self) -> bool {
+        self.bit_index >= self.len_bits()
+    }
+
+    /// Read `count` bits (0..=32) MSB-first as an unsigned integer.
+    /// Returns 0 if not enough bits remain.
+    pub fn read(&mut self, mut count: usize) -> u32 {
+        if !self.has(count) {
+            return 0;
+        }
+        let mut value: u32 = 0;
+        while count > 0 {
+            let current_byte = self.bytes[self.bit_index >> 3] as u32;
+            let remaining = 8 - (self.bit_index & 7); // remaining bits in this byte
+            let read = remaining.min(count); // bits read in this run
+            let shift = remaining - read;
+            let mask = 0xffu32 >> (8 - read);
+            value = (value << read) | ((current_byte & (mask << shift)) >> shift);
+            self.bit_index += read;
+            count -= read;
+        }
+        value
+    }
+
+    /// Align the read position to the next byte boundary.
+    pub fn align(&mut self) {
+        self.bit_index = ((self.bit_index + 7) >> 3) << 3;
+    }
+
+    /// Skip `count` bits if available.
+    pub fn skip(&mut self, count: usize) {
+        if self.has(count) {
+            self.bit_index += count;
+        }
+    }
+
+    /// Align, then skip consecutive bytes equal to `v`. Returns the number
+    /// of bytes skipped.
+    pub fn skip_bytes(&mut self, v: u8) -> usize {
+        self.align();
+        let mut skipped = 0;
+        while self.has(8) && self.bytes[self.bit_index >> 3] == v {
+            self.bit_index += 8;
+            skipped += 1;
+        }
+        skipped
+    }
+
+    /// Align, then scan forward for the next `00 00 01 xx` start code.
+    /// Consumes up to and including the 4 marker bytes and returns `xx`,
+    /// or -1 if none is found.
+    pub fn next_start_code(&mut self) -> i32 {
+        self.align();
+        while self.has(5 << 3) {
+            let byte_index = self.bit_index >> 3;
+            if self.bytes[byte_index] == 0x00
+                && self.bytes[byte_index + 1] == 0x00
+                && self.bytes[byte_index + 2] == 0x01
+            {
+                self.bit_index = (byte_index + 4) << 3;
+                return self.bytes[byte_index + 3] as i32;
+            }
+            self.bit_index += 8;
+        }
+        -1
+    }
+
+    /// Scan forward until the start code `code` (or end of buffer).
+    pub fn find_start_code(&mut self, code: i32) -> i32 {
+        loop {
+            let current = self.next_start_code();
+            if current == code || current == -1 {
+                return current;
+            }
+        }
+    }
+
+    /// Peek whether start code `code` appears ahead, without consuming.
+    pub fn has_start_code(&mut self, code: i32) -> i32 {
+        let previous = self.bit_index;
+        let current = self.find_start_code(code);
+        self.bit_index = previous;
+        current
+    }
+
+    /// Current read position in bytes (rounded down).
+    pub fn tell(&self) -> usize {
+        self.bit_index >> 3
+    }
+
+    /// Seek to a byte position.
+    pub fn seek(&mut self, byte_pos: usize) {
+        self.bit_index = byte_pos << 3;
+    }
+
+    /// Borrow the bytes of the next `count` bytes from the current
+    /// (byte-aligned) position, without advancing. Returns None if out of range.
+    pub fn peek_bytes(&self, count: usize) -> Option<&[u8]> {
+        let start = self.bit_index >> 3;
+        self.bytes.get(start..start + count)
+    }
+
+    /// Decode a value using a binary VLC table (PL_MPEG layout).
+    pub fn read_vlc(&mut self, table: &[Vlc]) -> i16 {
+        let mut state = Vlc { index: 0, value: 0 };
+        loop {
+            let bit = self.read(1) as i16;
+            state = table[(state.index + bit) as usize];
+            if state.index <= 0 {
+                break;
+            }
+        }
+        state.value
+    }
+
+    /// Decode a value using an unsigned binary VLC table.
+    pub fn read_vlc_uint(&mut self, table: &[VlcUint]) -> u16 {
+        let mut state = VlcUint { index: 0, value: 0 };
+        loop {
+            let bit = self.read(1) as i16;
+            let e = table[(state.index + bit) as usize];
+            state = e;
+            if state.index <= 0 {
+                break;
+            }
+        }
+        state.value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_bits_msb_first() {
+        // 0b1011_0010, 0b1100_0000
+        let mut b = Buffer::new(vec![0b1011_0010, 0b1100_0000]);
+        assert_eq!(b.read(1), 1);
+        assert_eq!(b.read(3), 0b011);
+        assert_eq!(b.read(4), 0b0010);
+        assert_eq!(b.read(2), 0b11);
+    }
+
+    #[test]
+    fn test_has_and_ended() {
+        let mut b = Buffer::new(vec![0xff, 0xff]);
+        assert!(b.has(16));
+        assert!(!b.has(17));
+        b.read(16);
+        assert!(b.has_ended());
+    }
+
+    #[test]
+    fn test_read_past_end_returns_zero() {
+        let mut b = Buffer::new(vec![0xab]);
+        assert_eq!(b.read(16), 0); // not enough bits
+        assert_eq!(b.read(8), 0xab);
+    }
+
+    #[test]
+    fn test_align() {
+        let mut b = Buffer::new(vec![0xff, 0x0f]);
+        b.read(3);
+        b.align();
+        assert_eq!(b.tell(), 1);
+        b.align(); // already aligned, no-op
+        assert_eq!(b.tell(), 1);
+    }
+
+    #[test]
+    fn test_skip_bytes() {
+        let mut b = Buffer::new(vec![0xff, 0xff, 0xff, 0x01]);
+        let skipped = b.skip_bytes(0xff);
+        assert_eq!(skipped, 3);
+        assert_eq!(b.read(8), 0x01);
+    }
+
+    #[test]
+    fn test_next_start_code() {
+        // padding, then 00 00 01 B3, then a byte
+        let mut b = Buffer::new(vec![0x12, 0x34, 0x00, 0x00, 0x01, 0xb3, 0x99]);
+        assert_eq!(b.next_start_code(), 0xb3);
+        assert_eq!(b.read(8), 0x99);
+    }
+
+    #[test]
+    fn test_find_start_code_skips_others() {
+        // 00 00 01 BA ... 00 00 01 E0
+        let mut b = Buffer::new(vec![
+            0x00, 0x00, 0x01, 0xba, 0x55, 0x00, 0x00, 0x01, 0xe0, 0x42,
+        ]);
+        assert_eq!(b.find_start_code(0xe0), 0xe0);
+        assert_eq!(b.read(8), 0x42);
+    }
+
+    #[test]
+    fn test_has_start_code_does_not_consume() {
+        let mut b = Buffer::new(vec![0x00, 0x00, 0x01, 0xe0, 0x42]);
+        assert_eq!(b.has_start_code(0xe0), 0xe0);
+        // position unchanged: still at the start
+        assert_eq!(b.tell(), 0);
+    }
+}

--- a/crates/native32emu-core/src/mpeg/demux.rs
+++ b/crates/native32emu-core/src/mpeg/demux.rs
@@ -1,0 +1,332 @@
+// MPEG-PS (Program Stream) demuxer.
+//
+// Ported to Rust from PL_MPEG (https://github.com/phoboslab/pl_mpeg) by
+// Dominic Szablewski, originally MIT licensed. It splits an MPEG-1 program
+// stream into its elementary video and audio streams.
+
+use super::buffer::Buffer;
+
+// Pack/system start codes.
+const START_PACK: i32 = 0xBA;
+const START_SYSTEM: i32 = 0xBB;
+
+// Packet stream-id start codes.
+pub const PACKET_PRIVATE: i32 = 0xBD;
+pub const PACKET_AUDIO_1: i32 = 0xC0;
+pub const PACKET_AUDIO_4: i32 = 0xC3;
+pub const PACKET_VIDEO_1: i32 = 0xE0;
+
+/// Sentinel for "no presentation timestamp".
+pub const INVALID_TS: f64 = -1.0;
+
+/// A demuxed PES packet: its stream id, optional PTS (seconds) and payload.
+pub struct Packet {
+    pub ty: i32,
+    pub pts: f64,
+    pub data: Vec<u8>,
+}
+
+/// The elementary streams extracted from a program stream.
+#[derive(Default)]
+pub struct DemuxedStreams {
+    /// Concatenated video elementary stream (first video stream, 0xE0).
+    pub video: Vec<u8>,
+    /// Concatenated audio elementary stream (first audio stream, 0xC0).
+    pub audio: Vec<u8>,
+    pub num_video_streams: i32,
+    pub num_audio_streams: i32,
+}
+
+/// Streaming demuxer state.
+pub struct Demux {
+    buffer: Buffer,
+    start_code: i32,
+    has_pack_header: bool,
+    has_system_header: bool,
+    has_headers: bool,
+    num_audio_streams: i32,
+    num_video_streams: i32,
+    /// Length (bytes) of the packet currently positioned at the read head,
+    /// which must be skipped before the next packet is decoded.
+    current_length: usize,
+    next_type: i32,
+    next_length: usize,
+    next_pts: f64,
+}
+
+impl Demux {
+    pub fn new(data: Vec<u8>) -> Self {
+        let mut s = Self {
+            buffer: Buffer::new(data),
+            start_code: -1,
+            has_pack_header: false,
+            has_system_header: false,
+            has_headers: false,
+            num_audio_streams: 0,
+            num_video_streams: 0,
+            current_length: 0,
+            next_type: -1,
+            next_length: 0,
+            next_pts: INVALID_TS,
+        };
+        s.has_headers();
+        s
+    }
+
+    pub fn num_video_streams(&self) -> i32 {
+        self.num_video_streams
+    }
+
+    pub fn num_audio_streams(&self) -> i32 {
+        self.num_audio_streams
+    }
+
+    /// Decode the pack and system headers. Returns true once both are parsed.
+    pub fn has_headers(&mut self) -> bool {
+        if self.has_headers {
+            return true;
+        }
+
+        // Pack header.
+        if !self.has_pack_header {
+            if self.start_code != START_PACK && self.buffer.find_start_code(START_PACK) == -1 {
+                return false;
+            }
+            self.start_code = START_PACK;
+            if !self.buffer.has(64) {
+                return false;
+            }
+            self.start_code = -1;
+            if self.buffer.read(4) != 0x02 {
+                return false;
+            }
+            self.decode_time(); // system clock reference
+            self.buffer.skip(1);
+            self.buffer.skip(22); // mux_rate * 50
+            self.buffer.skip(1);
+            self.has_pack_header = true;
+        }
+
+        // System header.
+        if !self.has_system_header {
+            if self.start_code != START_SYSTEM && self.buffer.find_start_code(START_SYSTEM) == -1 {
+                return false;
+            }
+            self.start_code = START_SYSTEM;
+            if !self.buffer.has(56) {
+                return false;
+            }
+            self.start_code = -1;
+            self.buffer.skip(16); // header_length
+            self.buffer.skip(24); // rate bound
+            self.num_audio_streams = self.buffer.read(6) as i32;
+            self.buffer.skip(5); // misc flags
+            self.num_video_streams = self.buffer.read(5) as i32;
+            self.has_system_header = true;
+        }
+
+        self.has_headers = true;
+        true
+    }
+
+    /// Decode a 33-bit MPEG timestamp into seconds.
+    fn decode_time(&mut self) -> f64 {
+        let mut clock = (self.buffer.read(3) as i64) << 30;
+        self.buffer.skip(1);
+        clock |= (self.buffer.read(15) as i64) << 15;
+        self.buffer.skip(1);
+        clock |= self.buffer.read(15) as i64;
+        self.buffer.skip(1);
+        clock as f64 / 90000.0
+    }
+
+    /// Decode the next packet of any audio/video/private stream.
+    pub fn decode(&mut self) -> Option<Packet> {
+        if !self.has_headers() {
+            return None;
+        }
+
+        // Skip over the payload of the previously returned packet.
+        if self.current_length > 0 {
+            let bits = self.current_length << 3;
+            if !self.buffer.has(bits) {
+                return None;
+            }
+            self.buffer.skip(bits);
+            self.current_length = 0;
+        }
+
+        // A header was already located on a previous call.
+        if self.start_code != -1 {
+            let code = self.start_code;
+            return self.decode_packet(code);
+        }
+
+        loop {
+            self.start_code = self.buffer.next_start_code();
+            let sc = self.start_code;
+            if sc == PACKET_VIDEO_1
+                || sc == PACKET_PRIVATE
+                || (PACKET_AUDIO_1..=PACKET_AUDIO_4).contains(&sc)
+            {
+                return self.decode_packet(sc);
+            }
+            if sc == -1 {
+                return None;
+            }
+        }
+    }
+
+    fn decode_packet(&mut self, ty: i32) -> Option<Packet> {
+        if !self.buffer.has(16 << 3) {
+            return None;
+        }
+        self.start_code = -1;
+
+        self.next_type = ty;
+        let mut length = self.buffer.read(16) as i64;
+        length -= self.buffer.skip_bytes(0xff) as i64; // stuffing
+
+        // Skip P-STD buffer info if present.
+        if self.buffer.read(2) == 0x01 {
+            self.buffer.skip(16);
+            length -= 2;
+        }
+
+        let pts_dts_marker = self.buffer.read(2);
+        if pts_dts_marker == 0x03 {
+            self.next_pts = self.decode_time();
+            self.buffer.skip(40); // skip DTS
+            length -= 10;
+        } else if pts_dts_marker == 0x02 {
+            self.next_pts = self.decode_time();
+            length -= 5;
+        } else if pts_dts_marker == 0x00 {
+            self.next_pts = INVALID_TS;
+            self.buffer.skip(4);
+            length -= 1;
+        } else {
+            return None; // invalid
+        }
+
+        if length < 0 {
+            return None;
+        }
+        self.next_length = length as usize;
+        self.get_packet()
+    }
+
+    fn get_packet(&mut self) -> Option<Packet> {
+        let bits = self.next_length << 3;
+        if !self.buffer.has(bits) {
+            return None;
+        }
+        let data = self.buffer.peek_bytes(self.next_length)?.to_vec();
+        let packet = Packet {
+            ty: self.next_type,
+            pts: self.next_pts,
+            data,
+        };
+        self.current_length = self.next_length;
+        self.next_length = 0;
+        Some(packet)
+    }
+}
+
+/// Demux a whole in-memory program stream into its first video and audio
+/// elementary streams.
+pub fn demux_all(data: Vec<u8>) -> DemuxedStreams {
+    let mut demux = Demux::new(data);
+    let mut out = DemuxedStreams {
+        num_video_streams: demux.num_video_streams(),
+        num_audio_streams: demux.num_audio_streams(),
+        ..Default::default()
+    };
+
+    while let Some(packet) = demux.decode() {
+        if packet.ty == PACKET_VIDEO_1 {
+            out.video.extend_from_slice(&packet.data);
+        } else if packet.ty == PACKET_AUDIO_1 {
+            out.audio.extend_from_slice(&packet.data);
+        }
+        // Other audio streams / private streams are ignored for now.
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal MPEG-PS: pack header, system header, one video PES and
+    /// one audio PES, then an end code.
+    fn build_stream() -> Vec<u8> {
+        let mut d = Vec::new();
+
+        // Pack header: 00 00 01 BA, then "0010" + SCR + mux_rate.
+        d.extend_from_slice(&[0x00, 0x00, 0x01, 0xBA]);
+        // 4 bits 0010 marker + 33-bit SCR + markers + 22-bit mux_rate + marker.
+        // Use a known-good 8-byte pack body (all zero SCR, mux_rate arbitrary).
+        // byte0: 0010 001 0 -> 0x21 (matches real files)
+        d.extend_from_slice(&[0x21, 0x00, 0x01, 0x00, 0x01, 0x80, 0x80, 0x01]);
+
+        // System header: 00 00 01 BB, length(16), then fields.
+        d.extend_from_slice(&[0x00, 0x00, 0x01, 0xBB]);
+        // header_length = 6
+        d.extend_from_slice(&[0x00, 0x06]);
+        d.extend_from_slice(&[0x80, 0x00, 0x00]); // rate bound (24)
+                                                  // num_audio_streams (6 bits) = 1 -> 0b000001_xx; pack as 0x04 then flags
+                                                  // byte: aaaaaa ff -> audio=1 (000001), 2 misc bits = 00 -> 0b00000100 = 0x04
+        d.push(0x04);
+        d.push(0x00); // remaining misc flags (3) + video streams start...
+                      // video_streams (5 bits): place 1 in next byte top bits -> 0b00001_xxx
+        d.push(0x08);
+
+        // Video PES: 00 00 01 E0, length, no PTS, payload.
+        let payload_v = [0xAAu8, 0xBB, 0xCC, 0xDD];
+        d.extend_from_slice(&[0x00, 0x00, 0x01, 0xE0]);
+        // length = 1 (marker byte) + payload
+        let len_v = 1 + payload_v.len();
+        d.push((len_v >> 8) as u8);
+        d.push((len_v & 0xff) as u8);
+        d.push(0x0f); // pts_dts marker bits 00 -> top 2 bits 0, lower bits arbitrary; read(2)=00
+        d.extend_from_slice(&payload_v);
+
+        // Audio PES: 00 00 01 C0, length, no PTS, payload.
+        let payload_a = [0x11u8, 0x22, 0x33];
+        d.extend_from_slice(&[0x00, 0x00, 0x01, 0xC0]);
+        let len_a = 1 + payload_a.len();
+        d.push((len_a >> 8) as u8);
+        d.push((len_a & 0xff) as u8);
+        d.push(0x0f);
+        d.extend_from_slice(&payload_a);
+
+        // End code.
+        d.extend_from_slice(&[0x00, 0x00, 0x01, 0xB9]);
+        // PL_MPEG needs 16 bytes of lookahead before decoding a packet, so pad
+        // the tail (real files are large enough that this never matters).
+        d.extend_from_slice(&[0xFF; 16]);
+        d
+    }
+
+    #[test]
+    fn test_demux_splits_streams() {
+        let stream = build_stream();
+        let out = demux_all(stream);
+        assert_eq!(out.video, vec![0xAA, 0xBB, 0xCC, 0xDD]);
+        assert_eq!(out.audio, vec![0x11, 0x22, 0x33]);
+    }
+
+    #[test]
+    fn test_demux_real_file_header() {
+        // A real MPEG-1 PS begins with 00 00 01 BA and an 0x21 marker byte.
+        let data = vec![
+            0x00, 0x00, 0x01, 0xBA, 0x21, 0x00, 0x01, 0x00, 0x01, 0x80, 0x80, 0x01,
+        ];
+        // Should at least parse the pack header without panicking.
+        let mut demux = Demux::new(data);
+        // No system header / packets present, so decode yields nothing.
+        assert!(demux.decode().is_none());
+    }
+}

--- a/crates/native32emu-core/src/mpeg/mod.rs
+++ b/crates/native32emu-core/src/mpeg/mod.rs
@@ -13,8 +13,10 @@
 pub mod audio;
 pub mod buffer;
 pub mod demux;
+pub mod player;
 pub mod video;
 
 pub use audio::{Audio, Samples};
 pub use demux::{demux_all, DemuxedStreams};
+pub use player::VideoPlayer;
 pub use video::{Frame, Plane, Video};

--- a/crates/native32emu-core/src/mpeg/mod.rs
+++ b/crates/native32emu-core/src/mpeg/mod.rs
@@ -1,0 +1,16 @@
+// Pure-Rust MPEG-1 playback for SSL_PlayNext pre-content cutscenes/logos.
+//
+// Ported from PL_MPEG (https://github.com/phoboslab/pl_mpeg) by Dominic
+// Szablewski, which is MIT licensed. This avoids any C/FFI dependency so the
+// decoder builds the same way on every target the emulator supports.
+//
+// Module layout (built up incrementally):
+//   - buffer: MSB-first bit reader over an in-memory stream
+//   - demux:  MPEG-PS demuxer (splits video/audio elementary streams)
+//   - video:  MPEG-1 video decoder (TODO)
+//   - audio:  MP2 audio decoder (TODO)
+
+pub mod buffer;
+pub mod demux;
+
+pub use demux::{demux_all, DemuxedStreams};

--- a/crates/native32emu-core/src/mpeg/mod.rs
+++ b/crates/native32emu-core/src/mpeg/mod.rs
@@ -12,5 +12,7 @@
 
 pub mod buffer;
 pub mod demux;
+pub mod video;
 
 pub use demux::{demux_all, DemuxedStreams};
+pub use video::{Frame, Plane, Video};

--- a/crates/native32emu-core/src/mpeg/mod.rs
+++ b/crates/native32emu-core/src/mpeg/mod.rs
@@ -10,9 +10,11 @@
 //   - video:  MPEG-1 video decoder (TODO)
 //   - audio:  MP2 audio decoder (TODO)
 
+pub mod audio;
 pub mod buffer;
 pub mod demux;
 pub mod video;
 
+pub use audio::{Audio, Samples};
 pub use demux::{demux_all, DemuxedStreams};
 pub use video::{Frame, Plane, Video};

--- a/crates/native32emu-core/src/mpeg/player.rs
+++ b/crates/native32emu-core/src/mpeg/player.rs
@@ -7,10 +7,10 @@ use super::video::Video;
 pub struct VideoPlayer {
     video: Video,
     framerate: f64,
-    /// Current playback time, in seconds.
+    /// Current playback time, in seconds (accumulator, not a loop counter).
     time: f64,
-    /// Time at which the next frame should be decoded.
-    next_decode_time: f64,
+    /// Number of frames decoded/shown so far (drives the decode loop).
+    frames_shown: u64,
     /// Index of the most recently decoded displayable frame.
     cur_frame: Option<usize>,
     finished: bool,
@@ -33,7 +33,7 @@ impl VideoPlayer {
             video,
             framerate,
             time: 0.0,
-            next_decode_time: 0.0,
+            frames_shown: 0,
             cur_frame: None,
             finished: false,
         })
@@ -48,11 +48,14 @@ impl VideoPlayer {
     pub fn advance_and_render(&mut self, dt: f64, dst: &mut [u32], dst_w: usize, dst_h: usize) {
         if !self.finished {
             self.time += dt;
-            while self.time >= self.next_decode_time {
+            // Number of frames that should have been shown by `time`. Decoding
+            // is driven by this integer target, not a floating-point counter.
+            let target = (self.time * self.framerate) as u64;
+            while self.frames_shown <= target {
                 match self.video.decode() {
                     Some(idx) => {
                         self.cur_frame = Some(idx);
-                        self.next_decode_time += 1.0 / self.framerate;
+                        self.frames_shown += 1;
                     }
                     None => {
                         self.finished = true;

--- a/crates/native32emu-core/src/mpeg/player.rs
+++ b/crates/native32emu-core/src/mpeg/player.rs
@@ -1,0 +1,69 @@
+// Drives an MPEG-1 video stream for real-time playback: decodes frames on a
+// time budget and renders the current frame (scaled) into an XRGB8888 buffer.
+// Audio is decoded separately by the caller and handed to the audio engine.
+
+use super::video::Video;
+
+pub struct VideoPlayer {
+    video: Video,
+    framerate: f64,
+    /// Current playback time, in seconds.
+    time: f64,
+    /// Time at which the next frame should be decoded.
+    next_decode_time: f64,
+    /// Index of the most recently decoded displayable frame.
+    cur_frame: Option<usize>,
+    finished: bool,
+}
+
+impl VideoPlayer {
+    /// Create a player over a video elementary stream. Returns `None` if no
+    /// sequence header could be parsed.
+    pub fn new(video_es: Vec<u8>) -> Option<Self> {
+        let mut video = Video::new(video_es);
+        if !video.has_header() {
+            return None;
+        }
+        let framerate = if video.framerate() > 0.0 {
+            video.framerate()
+        } else {
+            25.0
+        };
+        Some(Self {
+            video,
+            framerate,
+            time: 0.0,
+            next_decode_time: 0.0,
+            cur_frame: None,
+            finished: false,
+        })
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.finished
+    }
+
+    /// Advance playback by `dt` seconds, decoding frames as needed, and render
+    /// the current frame into `dst` (dst_w x dst_h XRGB8888).
+    pub fn advance_and_render(&mut self, dt: f64, dst: &mut [u32], dst_w: usize, dst_h: usize) {
+        if !self.finished {
+            self.time += dt;
+            while self.time >= self.next_decode_time {
+                match self.video.decode() {
+                    Some(idx) => {
+                        self.cur_frame = Some(idx);
+                        self.next_decode_time += 1.0 / self.framerate;
+                    }
+                    None => {
+                        self.finished = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if let Some(idx) = self.cur_frame {
+            self.video.frame(idx).write_rgb_scaled(dst, dst_w, dst_h);
+        }
+    }
+}

--- a/crates/native32emu-core/src/mpeg/video.rs
+++ b/crates/native32emu-core/src/mpeg/video.rs
@@ -1591,3 +1591,42 @@ fn idct(block: &mut [i32; 64]) {
         i += 8;
     }
 }
+
+impl Frame {
+    /// Convert this YCrCb frame to XRGB8888 and write it into `dst`, scaling
+    /// (nearest-neighbour) to `dst_w` x `dst_h`. `dst` must hold dst_w*dst_h u32.
+    /// Uses the BT.601 conversion (same coefficients as PL_MPEG).
+    pub fn write_rgb_scaled(&self, dst: &mut [u32], dst_w: usize, dst_h: usize) {
+        if dst_w == 0 || dst_h == 0 {
+            return;
+        }
+        let sw = self.width.max(1);
+        let sh = self.height.max(1);
+        let yw = self.y.width;
+        let cw = self.cr.width;
+
+        for ty in 0..dst_h {
+            let sy = (ty * sh / dst_h).min(sh - 1);
+            let y_row = sy * yw;
+            let c_row = (sy / 2) * cw;
+            let d_row = ty * dst_w;
+            for tx in 0..dst_w {
+                let sx = (tx * sw / dst_w).min(sw - 1);
+                let yv = self.y.data[y_row + sx] as i32;
+                let ci = c_row + (sx / 2);
+                let cr = self.cr.data[ci] as i32 - 128;
+                let cb = self.cb.data[ci] as i32 - 128;
+
+                let yy = ((yv - 16) * 76309) >> 16;
+                let r = (cr * 104597) >> 16;
+                let g = (cb * 25674 + cr * 53278) >> 16;
+                let b = (cb * 132201) >> 16;
+
+                let rr = clamp_u8(yy + r) as u32;
+                let gg = clamp_u8(yy - g) as u32;
+                let bb = clamp_u8(yy + b) as u32;
+                dst[d_row + tx] = 0xFF00_0000 | (rr << 16) | (gg << 8) | bb;
+            }
+        }
+    }
+}

--- a/crates/native32emu-core/src/mpeg/video.rs
+++ b/crates/native32emu-core/src/mpeg/video.rs
@@ -1,0 +1,1593 @@
+// MPEG-1 video decoder.
+//
+// Ported to Rust from PL_MPEG (https://github.com/phoboslab/pl_mpeg) by Dominic
+// Szablewski, originally MIT licensed; itself inspired by Zoltan Korandi's Java
+// MPEG-1 decoder. Decodes an MPEG-1 video elementary stream into YCrCb frames.
+
+use super::buffer::Buffer;
+
+const PICTURE_TYPE_INTRA: i32 = 1;
+const PICTURE_TYPE_PREDICTIVE: i32 = 2;
+const PICTURE_TYPE_B: i32 = 3;
+
+const START_SEQUENCE: i32 = 0xB3;
+const START_SLICE_FIRST: i32 = 0x01;
+const START_SLICE_LAST: i32 = 0xAF;
+const START_PICTURE: i32 = 0x00;
+const START_EXTENSION: i32 = 0xB5;
+const START_USER_DATA: i32 = 0xB2;
+
+fn is_slice_start_code(c: i32) -> bool {
+    (START_SLICE_FIRST..=START_SLICE_LAST).contains(&c)
+}
+
+const PIXEL_ASPECT_RATIO: [f64; 14] = [
+    1.0000, 0.6735, 0.7031, 0.7615, 0.8055, 0.8437, 0.8935, 0.9157, 0.9815, 1.0255, 1.0695, 1.0950,
+    1.1575, 1.2051,
+];
+
+const PICTURE_RATE: [f64; 16] = [
+    0.000, 23.976, 24.000, 25.000, 29.970, 30.000, 50.000, 59.940, 60.000, 0.000, 0.000, 0.000,
+    0.000, 0.000, 0.000, 0.000,
+];
+
+const ZIG_ZAG: [usize; 64] = [
+    0, 1, 8, 16, 9, 2, 3, 10, 17, 24, 32, 25, 18, 11, 4, 5, 12, 19, 26, 33, 40, 48, 41, 34, 27, 20,
+    13, 6, 7, 14, 21, 28, 35, 42, 49, 56, 57, 50, 43, 36, 29, 22, 15, 23, 30, 37, 44, 51, 58, 59,
+    52, 45, 38, 31, 39, 46, 53, 60, 61, 54, 47, 55, 62, 63,
+];
+
+const INTRA_QUANT_MATRIX: [u8; 64] = [
+    8, 16, 19, 22, 26, 27, 29, 34, 16, 16, 22, 24, 27, 29, 34, 37, 19, 22, 26, 27, 29, 34, 34, 38,
+    22, 22, 26, 27, 29, 34, 37, 40, 22, 26, 27, 29, 32, 35, 40, 48, 26, 27, 29, 32, 35, 40, 48, 58,
+    26, 27, 29, 34, 38, 46, 56, 69, 27, 29, 35, 38, 46, 56, 69, 83,
+];
+
+const NON_INTRA_QUANT_MATRIX: [u8; 64] = [16; 64];
+
+const PREMULTIPLIER_MATRIX: [i32; 64] = [
+    32, 44, 42, 38, 32, 25, 17, 9, 44, 62, 58, 52, 44, 35, 24, 12, 42, 58, 55, 49, 42, 33, 23, 12,
+    38, 52, 49, 44, 38, 30, 20, 10, 32, 44, 42, 38, 32, 25, 17, 9, 25, 35, 33, 30, 25, 20, 14, 7,
+    17, 24, 23, 20, 17, 14, 9, 5, 9, 12, 12, 10, 9, 7, 5, 2,
+];
+
+// VLC tables. Each entry is (index, value): index > 0 points to the next node
+// (`index + bit`), index <= 0 terminates with `value`.
+
+const MACROBLOCK_ADDRESS_INCREMENT: &[(i16, i16)] = &[
+    (2, 0),
+    (0, 1),
+    (4, 0),
+    (6, 0),
+    (8, 0),
+    (10, 0),
+    (0, 3),
+    (0, 2),
+    (12, 0),
+    (14, 0),
+    (0, 5),
+    (0, 4),
+    (16, 0),
+    (18, 0),
+    (0, 7),
+    (0, 6),
+    (20, 0),
+    (22, 0),
+    (24, 0),
+    (26, 0),
+    (28, 0),
+    (30, 0),
+    (32, 0),
+    (34, 0),
+    (36, 0),
+    (38, 0),
+    (0, 9),
+    (0, 8),
+    (-1, 0),
+    (40, 0),
+    (-1, 0),
+    (42, 0),
+    (44, 0),
+    (46, 0),
+    (0, 15),
+    (0, 14),
+    (0, 13),
+    (0, 12),
+    (0, 11),
+    (0, 10),
+    (48, 0),
+    (50, 0),
+    (52, 0),
+    (54, 0),
+    (56, 0),
+    (58, 0),
+    (60, 0),
+    (62, 0),
+    (64, 0),
+    (-1, 0),
+    (-1, 0),
+    (66, 0),
+    (68, 0),
+    (70, 0),
+    (72, 0),
+    (74, 0),
+    (76, 0),
+    (78, 0),
+    (0, 21),
+    (0, 20),
+    (0, 19),
+    (0, 18),
+    (0, 17),
+    (0, 16),
+    (0, 35),
+    (-1, 0),
+    (-1, 0),
+    (0, 34),
+    (0, 33),
+    (0, 32),
+    (0, 31),
+    (0, 30),
+    (0, 29),
+    (0, 28),
+    (0, 27),
+    (0, 26),
+    (0, 25),
+    (0, 24),
+    (0, 23),
+    (0, 22),
+];
+
+const MACROBLOCK_TYPE_INTRA: &[(i16, i16)] = &[(2, 0), (0, 0x01), (-1, 0), (0, 0x11)];
+
+const MACROBLOCK_TYPE_PREDICTIVE: &[(i16, i16)] = &[
+    (2, 0),
+    (0, 0x0a),
+    (4, 0),
+    (0, 0x02),
+    (6, 0),
+    (0, 0x08),
+    (8, 0),
+    (10, 0),
+    (12, 0),
+    (0, 0x12),
+    (0, 0x1a),
+    (0, 0x01),
+    (-1, 0),
+    (0, 0x11),
+];
+
+const MACROBLOCK_TYPE_B: &[(i16, i16)] = &[
+    (2, 0),
+    (4, 0),
+    (6, 0),
+    (8, 0),
+    (0, 0x0c),
+    (0, 0x0e),
+    (10, 0),
+    (12, 0),
+    (0, 0x04),
+    (0, 0x06),
+    (14, 0),
+    (16, 0),
+    (0, 0x08),
+    (0, 0x0a),
+    (18, 0),
+    (20, 0),
+    (0, 0x1e),
+    (0, 0x01),
+    (-1, 0),
+    (0, 0x11),
+    (0, 0x16),
+    (0, 0x1a),
+];
+
+fn macroblock_type_table(picture_type: i32) -> &'static [(i16, i16)] {
+    match picture_type {
+        PICTURE_TYPE_INTRA => MACROBLOCK_TYPE_INTRA,
+        PICTURE_TYPE_PREDICTIVE => MACROBLOCK_TYPE_PREDICTIVE,
+        _ => MACROBLOCK_TYPE_B,
+    }
+}
+
+const CODE_BLOCK_PATTERN: &[(i16, i16)] = &[
+    (2, 0),
+    (4, 0),
+    (6, 0),
+    (8, 0),
+    (10, 0),
+    (12, 0),
+    (14, 0),
+    (16, 0),
+    (18, 0),
+    (20, 0),
+    (22, 0),
+    (24, 0),
+    (26, 0),
+    (0, 60),
+    (28, 0),
+    (30, 0),
+    (32, 0),
+    (34, 0),
+    (36, 0),
+    (38, 0),
+    (40, 0),
+    (42, 0),
+    (44, 0),
+    (46, 0),
+    (0, 32),
+    (0, 16),
+    (0, 8),
+    (0, 4),
+    (48, 0),
+    (50, 0),
+    (52, 0),
+    (54, 0),
+    (56, 0),
+    (58, 0),
+    (60, 0),
+    (62, 0),
+    (0, 62),
+    (0, 2),
+    (0, 61),
+    (0, 1),
+    (0, 56),
+    (0, 52),
+    (0, 44),
+    (0, 28),
+    (0, 40),
+    (0, 20),
+    (0, 48),
+    (0, 12),
+    (64, 0),
+    (66, 0),
+    (68, 0),
+    (70, 0),
+    (72, 0),
+    (74, 0),
+    (76, 0),
+    (78, 0),
+    (80, 0),
+    (82, 0),
+    (84, 0),
+    (86, 0),
+    (0, 63),
+    (0, 3),
+    (0, 36),
+    (0, 24),
+    (88, 0),
+    (90, 0),
+    (92, 0),
+    (94, 0),
+    (96, 0),
+    (98, 0),
+    (100, 0),
+    (102, 0),
+    (104, 0),
+    (106, 0),
+    (108, 0),
+    (110, 0),
+    (112, 0),
+    (114, 0),
+    (116, 0),
+    (118, 0),
+    (0, 34),
+    (0, 18),
+    (0, 10),
+    (0, 6),
+    (0, 33),
+    (0, 17),
+    (0, 9),
+    (0, 5),
+    (-1, 0),
+    (120, 0),
+    (122, 0),
+    (124, 0),
+    (0, 58),
+    (0, 54),
+    (0, 46),
+    (0, 30),
+    (0, 57),
+    (0, 53),
+    (0, 45),
+    (0, 29),
+    (0, 38),
+    (0, 26),
+    (0, 37),
+    (0, 25),
+    (0, 43),
+    (0, 23),
+    (0, 51),
+    (0, 15),
+    (0, 42),
+    (0, 22),
+    (0, 50),
+    (0, 14),
+    (0, 41),
+    (0, 21),
+    (0, 49),
+    (0, 13),
+    (0, 35),
+    (0, 19),
+    (0, 11),
+    (0, 7),
+    (0, 39),
+    (0, 27),
+    (0, 59),
+    (0, 55),
+    (0, 47),
+    (0, 31),
+];
+
+const MOTION: &[(i16, i16)] = &[
+    (2, 0),
+    (0, 0),
+    (4, 0),
+    (6, 0),
+    (8, 0),
+    (10, 0),
+    (0, 1),
+    (0, -1),
+    (12, 0),
+    (14, 0),
+    (0, 2),
+    (0, -2),
+    (16, 0),
+    (18, 0),
+    (0, 3),
+    (0, -3),
+    (20, 0),
+    (22, 0),
+    (24, 0),
+    (26, 0),
+    (-1, 0),
+    (28, 0),
+    (30, 0),
+    (32, 0),
+    (34, 0),
+    (36, 0),
+    (0, 4),
+    (0, -4),
+    (-1, 0),
+    (38, 0),
+    (40, 0),
+    (42, 0),
+    (0, 7),
+    (0, -7),
+    (0, 6),
+    (0, -6),
+    (0, 5),
+    (0, -5),
+    (44, 0),
+    (46, 0),
+    (48, 0),
+    (50, 0),
+    (52, 0),
+    (54, 0),
+    (56, 0),
+    (58, 0),
+    (60, 0),
+    (62, 0),
+    (64, 0),
+    (66, 0),
+    (0, 10),
+    (0, -10),
+    (0, 9),
+    (0, -9),
+    (0, 8),
+    (0, -8),
+    (0, 16),
+    (0, -16),
+    (0, 15),
+    (0, -15),
+    (0, 14),
+    (0, -14),
+    (0, 13),
+    (0, -13),
+    (0, 12),
+    (0, -12),
+    (0, 11),
+    (0, -11),
+];
+
+const DCT_SIZE_LUMINANCE: &[(i16, i16)] = &[
+    (2, 0),
+    (4, 0),
+    (0, 1),
+    (0, 2),
+    (6, 0),
+    (8, 0),
+    (0, 0),
+    (0, 3),
+    (0, 4),
+    (10, 0),
+    (0, 5),
+    (12, 0),
+    (0, 6),
+    (14, 0),
+    (0, 7),
+    (16, 0),
+    (0, 8),
+    (-1, 0),
+];
+
+const DCT_SIZE_CHROMINANCE: &[(i16, i16)] = &[
+    (2, 0),
+    (4, 0),
+    (0, 0),
+    (0, 1),
+    (0, 2),
+    (6, 0),
+    (0, 3),
+    (8, 0),
+    (0, 4),
+    (10, 0),
+    (0, 5),
+    (12, 0),
+    (0, 6),
+    (14, 0),
+    (0, 7),
+    (16, 0),
+    (0, 8),
+    (-1, 0),
+];
+
+fn dct_size_table(plane_index: usize) -> &'static [(i16, i16)] {
+    if plane_index == 0 {
+        DCT_SIZE_LUMINANCE
+    } else {
+        DCT_SIZE_CHROMINANCE
+    }
+}
+
+// dct_coeff bitmap: 0xff00 run, 0x00ff level. Values are unsigned; the sign bit
+// follows in the stream. 0xffff = escape.
+const DCT_COEFF: &[(i16, u16)] = &[
+    (2, 0),
+    (0, 0x0001),
+    (4, 0),
+    (6, 0),
+    (8, 0),
+    (10, 0),
+    (12, 0),
+    (0, 0x0101),
+    (14, 0),
+    (16, 0),
+    (18, 0),
+    (20, 0),
+    (0, 0x0002),
+    (0, 0x0201),
+    (22, 0),
+    (24, 0),
+    (26, 0),
+    (28, 0),
+    (30, 0),
+    (0, 0x0003),
+    (0, 0x0401),
+    (0, 0x0301),
+    (32, 0),
+    (0, 0xffff),
+    (34, 0),
+    (36, 0),
+    (0, 0x0701),
+    (0, 0x0601),
+    (0, 0x0102),
+    (0, 0x0501),
+    (38, 0),
+    (40, 0),
+    (42, 0),
+    (44, 0),
+    (0, 0x0202),
+    (0, 0x0901),
+    (0, 0x0004),
+    (0, 0x0801),
+    (46, 0),
+    (48, 0),
+    (50, 0),
+    (52, 0),
+    (54, 0),
+    (56, 0),
+    (58, 0),
+    (60, 0),
+    (0, 0x0d01),
+    (0, 0x0006),
+    (0, 0x0c01),
+    (0, 0x0b01),
+    (0, 0x0302),
+    (0, 0x0103),
+    (0, 0x0005),
+    (0, 0x0a01),
+    (62, 0),
+    (64, 0),
+    (66, 0),
+    (68, 0),
+    (70, 0),
+    (72, 0),
+    (74, 0),
+    (76, 0),
+    (78, 0),
+    (80, 0),
+    (82, 0),
+    (84, 0),
+    (86, 0),
+    (88, 0),
+    (90, 0),
+    (92, 0),
+    (0, 0x1001),
+    (0, 0x0502),
+    (0, 0x0007),
+    (0, 0x0203),
+    (0, 0x0104),
+    (0, 0x0f01),
+    (0, 0x0e01),
+    (0, 0x0402),
+    (94, 0),
+    (96, 0),
+    (98, 0),
+    (100, 0),
+    (102, 0),
+    (104, 0),
+    (106, 0),
+    (108, 0),
+    (110, 0),
+    (112, 0),
+    (114, 0),
+    (116, 0),
+    (118, 0),
+    (120, 0),
+    (122, 0),
+    (124, 0),
+    (-1, 0),
+    (126, 0),
+    (128, 0),
+    (130, 0),
+    (132, 0),
+    (134, 0),
+    (136, 0),
+    (138, 0),
+    (140, 0),
+    (142, 0),
+    (144, 0),
+    (146, 0),
+    (148, 0),
+    (150, 0),
+    (152, 0),
+    (154, 0),
+    (0, 0x000b),
+    (0, 0x0802),
+    (0, 0x0403),
+    (0, 0x000a),
+    (0, 0x0204),
+    (0, 0x0702),
+    (0, 0x1501),
+    (0, 0x1401),
+    (0, 0x0009),
+    (0, 0x1301),
+    (0, 0x1201),
+    (0, 0x0105),
+    (0, 0x0303),
+    (0, 0x0008),
+    (0, 0x0602),
+    (0, 0x1101),
+    (156, 0),
+    (158, 0),
+    (160, 0),
+    (162, 0),
+    (164, 0),
+    (166, 0),
+    (168, 0),
+    (170, 0),
+    (172, 0),
+    (174, 0),
+    (176, 0),
+    (178, 0),
+    (180, 0),
+    (182, 0),
+    (0, 0x0a02),
+    (0, 0x0902),
+    (0, 0x0503),
+    (0, 0x0304),
+    (0, 0x0205),
+    (0, 0x0107),
+    (0, 0x0106),
+    (0, 0x000f),
+    (0, 0x000e),
+    (0, 0x000d),
+    (0, 0x000c),
+    (0, 0x1a01),
+    (0, 0x1901),
+    (0, 0x1801),
+    (0, 0x1701),
+    (0, 0x1601),
+    (184, 0),
+    (186, 0),
+    (188, 0),
+    (190, 0),
+    (192, 0),
+    (194, 0),
+    (196, 0),
+    (198, 0),
+    (200, 0),
+    (202, 0),
+    (204, 0),
+    (206, 0),
+    (0, 0x001f),
+    (0, 0x001e),
+    (0, 0x001d),
+    (0, 0x001c),
+    (0, 0x001b),
+    (0, 0x001a),
+    (0, 0x0019),
+    (0, 0x0018),
+    (0, 0x0017),
+    (0, 0x0016),
+    (0, 0x0015),
+    (0, 0x0014),
+    (0, 0x0013),
+    (0, 0x0012),
+    (0, 0x0011),
+    (0, 0x0010),
+    (208, 0),
+    (210, 0),
+    (212, 0),
+    (214, 0),
+    (216, 0),
+    (218, 0),
+    (220, 0),
+    (222, 0),
+    (0, 0x0028),
+    (0, 0x0027),
+    (0, 0x0026),
+    (0, 0x0025),
+    (0, 0x0024),
+    (0, 0x0023),
+    (0, 0x0022),
+    (0, 0x0021),
+    (0, 0x0020),
+    (0, 0x010e),
+    (0, 0x010d),
+    (0, 0x010c),
+    (0, 0x010b),
+    (0, 0x010a),
+    (0, 0x0109),
+    (0, 0x0108),
+    (0, 0x0112),
+    (0, 0x0111),
+    (0, 0x0110),
+    (0, 0x010f),
+    (0, 0x0603),
+    (0, 0x1002),
+    (0, 0x0f02),
+    (0, 0x0e02),
+    (0, 0x0d02),
+    (0, 0x0c02),
+    (0, 0x0b02),
+    (0, 0x1f01),
+    (0, 0x1e01),
+    (0, 0x1d01),
+    (0, 0x1c01),
+    (0, 0x1b01),
+];
+
+/// A decoded image plane (Y, Cr or Cb). Size is rounded up to whole macroblocks.
+#[derive(Clone, Default)]
+pub struct Plane {
+    pub width: usize,
+    pub height: usize,
+    pub data: Vec<u8>,
+}
+
+/// A decoded YCrCb frame. `width`/`height` are the display size; the planes may
+/// be larger (rounded up to the nearest macroblock).
+#[derive(Clone, Default)]
+pub struct Frame {
+    pub width: usize,
+    pub height: usize,
+    pub y: Plane,
+    pub cr: Plane,
+    pub cb: Plane,
+}
+
+#[derive(Clone, Copy, Default)]
+struct Motion {
+    full_px: bool,
+    is_set: bool,
+    r_size: i32,
+    h: i32,
+    v: i32,
+}
+
+fn clamp_u8(n: i32) -> u8 {
+    n.clamp(0, 255) as u8
+}
+
+/// MPEG-1 video decoder over an in-memory elementary stream.
+pub struct Video {
+    buffer: Buffer,
+    framerate: f64,
+    pixel_aspect_ratio: f64,
+    time: f64,
+    last_frame_time: f64,
+    frames_decoded: i64,
+
+    width: usize,
+    height: usize,
+    mb_width: usize,
+    mb_height: usize,
+    mb_size: usize,
+    luma_width: usize,
+    luma_height: usize,
+    chroma_width: usize,
+    chroma_height: usize,
+
+    start_code: i32,
+    picture_type: i32,
+
+    motion_forward: Motion,
+    motion_backward: Motion,
+
+    has_sequence_header: bool,
+
+    quantizer_scale: i32,
+    slice_begin: bool,
+    macroblock_address: i32,
+    mb_row: usize,
+    mb_col: usize,
+
+    macroblock_type: i32,
+    macroblock_intra: bool,
+
+    dc_predictor: [i32; 3],
+
+    frames: Vec<Frame>,
+    cur: usize,
+    fwd: usize,
+    bwd: usize,
+
+    block_data: [i32; 64],
+    intra_quant_matrix: [u8; 64],
+    non_intra_quant_matrix: [u8; 64],
+
+    has_reference_frame: bool,
+    assume_no_b_frames: bool,
+}
+
+impl Video {
+    /// Create a decoder over a video elementary stream and parse the sequence
+    /// header if present.
+    pub fn new(video_es: Vec<u8>) -> Self {
+        let mut s = Self {
+            buffer: Buffer::new(video_es),
+            framerate: 0.0,
+            pixel_aspect_ratio: 0.0,
+            time: 0.0,
+            last_frame_time: 0.0,
+            frames_decoded: 0,
+            width: 0,
+            height: 0,
+            mb_width: 0,
+            mb_height: 0,
+            mb_size: 0,
+            luma_width: 0,
+            luma_height: 0,
+            chroma_width: 0,
+            chroma_height: 0,
+            start_code: -1,
+            picture_type: 0,
+            motion_forward: Motion::default(),
+            motion_backward: Motion::default(),
+            has_sequence_header: false,
+            quantizer_scale: 0,
+            slice_begin: false,
+            macroblock_address: 0,
+            mb_row: 0,
+            mb_col: 0,
+            macroblock_type: 0,
+            macroblock_intra: false,
+            dc_predictor: [128; 3],
+            frames: Vec::new(),
+            cur: 0,
+            fwd: 1,
+            bwd: 2,
+            block_data: [0; 64],
+            intra_quant_matrix: [0; 64],
+            non_intra_quant_matrix: [0; 64],
+            has_reference_frame: false,
+            assume_no_b_frames: false,
+        };
+        s.start_code = s.buffer.find_start_code(START_SEQUENCE);
+        if s.start_code != -1 {
+            s.decode_sequence_header();
+        }
+        s
+    }
+
+    pub fn has_header(&mut self) -> bool {
+        if self.has_sequence_header {
+            return true;
+        }
+        if self.start_code != START_SEQUENCE {
+            self.start_code = self.buffer.find_start_code(START_SEQUENCE);
+        }
+        if self.start_code == -1 {
+            return false;
+        }
+        self.decode_sequence_header()
+    }
+
+    pub fn width(&self) -> usize {
+        self.width
+    }
+    pub fn height(&self) -> usize {
+        self.height
+    }
+    pub fn framerate(&self) -> f64 {
+        self.framerate
+    }
+    pub fn pixel_aspect_ratio(&self) -> f64 {
+        self.pixel_aspect_ratio
+    }
+    /// Display time (seconds) of the most recently returned frame.
+    pub fn last_frame_time(&self) -> f64 {
+        self.last_frame_time
+    }
+    /// Borrow a decoded frame by index (as returned by [`decode`](Self::decode)).
+    pub fn frame(&self, index: usize) -> &Frame {
+        &self.frames[index]
+    }
+
+    /// Decode the next frame in display order. Returns the index of the frame
+    /// to display, or `None` if no more frames are available.
+    pub fn decode(&mut self) -> Option<usize> {
+        if !self.has_header() {
+            return None;
+        }
+        loop {
+            if self.start_code != START_PICTURE {
+                self.start_code = self.buffer.find_start_code(START_PICTURE);
+                if self.start_code == -1 {
+                    // Flush the last reference frame at end of stream.
+                    if self.has_reference_frame
+                        && !self.assume_no_b_frames
+                        && self.buffer.has_ended()
+                        && (self.picture_type == PICTURE_TYPE_INTRA
+                            || self.picture_type == PICTURE_TYPE_PREDICTIVE)
+                    {
+                        self.has_reference_frame = false;
+                        return Some(self.bwd);
+                    }
+                    return None;
+                }
+            }
+
+            // Need a full picture buffered before decoding it.
+            if self.buffer.has_start_code(START_PICTURE) == -1 && !self.buffer.has_ended() {
+                return None;
+            }
+
+            self.decode_picture();
+
+            let frame = if self.assume_no_b_frames {
+                Some(self.bwd)
+            } else if self.picture_type == PICTURE_TYPE_B {
+                Some(self.cur)
+            } else if self.has_reference_frame {
+                Some(self.fwd)
+            } else {
+                self.has_reference_frame = true;
+                None
+            };
+
+            if let Some(idx) = frame {
+                self.last_frame_time = self.time;
+                self.frames_decoded += 1;
+                self.time = self.frames_decoded as f64 / self.framerate;
+                return Some(idx);
+            }
+        }
+    }
+
+    fn decode_sequence_header(&mut self) -> bool {
+        let max_header_size = 64 + 2 * 64 * 8;
+        if !self.buffer.has(max_header_size) {
+            return false;
+        }
+
+        self.width = self.buffer.read(12) as usize;
+        self.height = self.buffer.read(12) as usize;
+        if self.width == 0 || self.height == 0 {
+            return false;
+        }
+
+        let mut par_code = self.buffer.read(4) as i32 - 1;
+        if par_code < 0 {
+            par_code = 0;
+        }
+        let par_last = (PIXEL_ASPECT_RATIO.len() - 1) as i32;
+        if par_code > par_last {
+            par_code = par_last;
+        }
+        self.pixel_aspect_ratio = PIXEL_ASPECT_RATIO[par_code as usize];
+
+        self.framerate = PICTURE_RATE[self.buffer.read(4) as usize];
+
+        // Skip bit_rate, marker, buffer_size and constrained bit.
+        self.buffer.skip(18 + 1 + 10 + 1);
+
+        // Custom intra quant matrix?
+        if self.buffer.read(1) != 0 {
+            for i in 0..64 {
+                let idx = ZIG_ZAG[i];
+                self.intra_quant_matrix[idx] = self.buffer.read(8) as u8;
+            }
+        } else {
+            self.intra_quant_matrix = INTRA_QUANT_MATRIX;
+        }
+
+        // Custom non-intra quant matrix?
+        if self.buffer.read(1) != 0 {
+            for i in 0..64 {
+                let idx = ZIG_ZAG[i];
+                self.non_intra_quant_matrix[idx] = self.buffer.read(8) as u8;
+            }
+        } else {
+            self.non_intra_quant_matrix = NON_INTRA_QUANT_MATRIX;
+        }
+
+        self.mb_width = (self.width + 15) >> 4;
+        self.mb_height = (self.height + 15) >> 4;
+        self.mb_size = self.mb_width * self.mb_height;
+        self.luma_width = self.mb_width << 4;
+        self.luma_height = self.mb_height << 4;
+        self.chroma_width = self.mb_width << 3;
+        self.chroma_height = self.mb_height << 3;
+
+        self.frames = vec![self.make_frame(), self.make_frame(), self.make_frame()];
+        self.cur = 0;
+        self.fwd = 1;
+        self.bwd = 2;
+
+        self.has_sequence_header = true;
+        true
+    }
+
+    fn make_frame(&self) -> Frame {
+        let luma = self.luma_width * self.luma_height;
+        let chroma = self.chroma_width * self.chroma_height;
+        Frame {
+            width: self.width,
+            height: self.height,
+            y: Plane {
+                width: self.luma_width,
+                height: self.luma_height,
+                data: vec![0; luma],
+            },
+            cr: Plane {
+                width: self.chroma_width,
+                height: self.chroma_height,
+                data: vec![0; chroma],
+            },
+            cb: Plane {
+                width: self.chroma_width,
+                height: self.chroma_height,
+                data: vec![0; chroma],
+            },
+        }
+    }
+}
+
+impl Video {
+    fn decode_picture(&mut self) {
+        self.buffer.skip(10); // temporal_reference
+        self.picture_type = self.buffer.read(3) as i32;
+        self.buffer.skip(16); // vbv_delay
+
+        // D frames or unknown coding type.
+        if self.picture_type <= 0 || self.picture_type > PICTURE_TYPE_B {
+            return;
+        }
+
+        if self.picture_type == PICTURE_TYPE_PREDICTIVE || self.picture_type == PICTURE_TYPE_B {
+            self.motion_forward.full_px = self.buffer.read(1) != 0;
+            let f_code = self.buffer.read(3) as i32;
+            if f_code == 0 {
+                return;
+            }
+            self.motion_forward.r_size = f_code - 1;
+        }
+
+        if self.picture_type == PICTURE_TYPE_B {
+            self.motion_backward.full_px = self.buffer.read(1) != 0;
+            let f_code = self.buffer.read(3) as i32;
+            if f_code == 0 {
+                return;
+            }
+            self.motion_backward.r_size = f_code - 1;
+        }
+
+        let frame_temp = self.fwd;
+        if self.picture_type == PICTURE_TYPE_INTRA || self.picture_type == PICTURE_TYPE_PREDICTIVE {
+            self.fwd = self.bwd;
+        }
+
+        // Find first slice start code; skip extension and user data.
+        loop {
+            self.start_code = self.buffer.next_start_code();
+            if self.start_code != START_EXTENSION && self.start_code != START_USER_DATA {
+                break;
+            }
+        }
+
+        while is_slice_start_code(self.start_code) {
+            self.decode_slice(self.start_code & 0xFF);
+            if self.macroblock_address >= self.mb_size as i32 - 1 {
+                break;
+            }
+            self.start_code = self.buffer.next_start_code();
+        }
+
+        // Rotate prediction frames for reference pictures.
+        if self.picture_type == PICTURE_TYPE_INTRA || self.picture_type == PICTURE_TYPE_PREDICTIVE {
+            self.bwd = self.cur;
+            self.cur = frame_temp;
+        }
+    }
+
+    fn decode_slice(&mut self, slice: i32) {
+        self.slice_begin = true;
+        self.macroblock_address = (slice - 1) * self.mb_width as i32 - 1;
+
+        self.motion_forward.h = 0;
+        self.motion_forward.v = 0;
+        self.motion_backward.h = 0;
+        self.motion_backward.v = 0;
+        self.dc_predictor = [128; 3];
+
+        self.quantizer_scale = self.buffer.read(5) as i32;
+
+        // Skip extra slice information.
+        while self.buffer.read(1) != 0 {
+            self.buffer.skip(8);
+        }
+
+        loop {
+            self.decode_macroblock();
+            if self.macroblock_address >= self.mb_size as i32 - 1 || !self.buffer.peek_non_zero(23)
+            {
+                break;
+            }
+        }
+    }
+
+    fn decode_macroblock(&mut self) {
+        // Decode address increment.
+        let mut increment = 0i32;
+        let mut t = self.buffer.read_vlc(MACROBLOCK_ADDRESS_INCREMENT) as i32;
+        while t == 34 {
+            // macroblock_stuffing
+            t = self.buffer.read_vlc(MACROBLOCK_ADDRESS_INCREMENT) as i32;
+        }
+        while t == 35 {
+            // macroblock_escape
+            increment += 33;
+            t = self.buffer.read_vlc(MACROBLOCK_ADDRESS_INCREMENT) as i32;
+        }
+        increment += t;
+
+        if self.slice_begin {
+            self.slice_begin = false;
+            self.macroblock_address += increment;
+        } else {
+            if self.macroblock_address + increment >= self.mb_size as i32 {
+                return; // invalid
+            }
+            if increment > 1 {
+                self.dc_predictor = [128; 3];
+                if self.picture_type == PICTURE_TYPE_PREDICTIVE {
+                    self.motion_forward.h = 0;
+                    self.motion_forward.v = 0;
+                }
+            }
+            while increment > 1 {
+                self.macroblock_address += 1;
+                self.mb_row = (self.macroblock_address as usize) / self.mb_width;
+                self.mb_col = (self.macroblock_address as usize) % self.mb_width;
+                self.predict_macroblock();
+                increment -= 1;
+            }
+            self.macroblock_address += 1;
+        }
+
+        if self.macroblock_address < 0 {
+            return;
+        }
+        self.mb_row = (self.macroblock_address as usize) / self.mb_width;
+        self.mb_col = (self.macroblock_address as usize) % self.mb_width;
+        if self.mb_col >= self.mb_width || self.mb_row >= self.mb_height {
+            return; // corrupt stream
+        }
+
+        let table = macroblock_type_table(self.picture_type);
+        self.macroblock_type = self.buffer.read_vlc(table) as i32;
+        self.macroblock_intra = (self.macroblock_type & 0x01) != 0;
+        self.motion_forward.is_set = (self.macroblock_type & 0x08) != 0;
+        self.motion_backward.is_set = (self.macroblock_type & 0x04) != 0;
+
+        if (self.macroblock_type & 0x10) != 0 {
+            self.quantizer_scale = self.buffer.read(5) as i32;
+        }
+
+        if self.macroblock_intra {
+            self.motion_forward.h = 0;
+            self.motion_forward.v = 0;
+            self.motion_backward.h = 0;
+            self.motion_backward.v = 0;
+        } else {
+            self.dc_predictor = [128; 3];
+            self.decode_motion_vectors();
+            self.predict_macroblock();
+        }
+
+        let cbp = if (self.macroblock_type & 0x02) != 0 {
+            self.buffer.read_vlc(CODE_BLOCK_PATTERN) as i32
+        } else if self.macroblock_intra {
+            0x3f
+        } else {
+            0
+        };
+
+        let mut mask = 0x20;
+        for block in 0..6 {
+            if (cbp & mask) != 0 {
+                self.decode_block(block);
+            }
+            mask >>= 1;
+        }
+    }
+
+    fn decode_motion_vectors(&mut self) {
+        if self.motion_forward.is_set {
+            let r_size = self.motion_forward.r_size;
+            self.motion_forward.h = self.decode_motion_vector(r_size, self.motion_forward.h);
+            self.motion_forward.v = self.decode_motion_vector(r_size, self.motion_forward.v);
+        } else if self.picture_type == PICTURE_TYPE_PREDICTIVE {
+            self.motion_forward.h = 0;
+            self.motion_forward.v = 0;
+        }
+
+        if self.motion_backward.is_set {
+            let r_size = self.motion_backward.r_size;
+            self.motion_backward.h = self.decode_motion_vector(r_size, self.motion_backward.h);
+            self.motion_backward.v = self.decode_motion_vector(r_size, self.motion_backward.v);
+        }
+    }
+
+    fn decode_motion_vector(&mut self, r_size: i32, mut motion: i32) -> i32 {
+        let fscale = 1 << r_size;
+        let m_code = self.buffer.read_vlc(MOTION) as i32;
+        let d;
+        if m_code != 0 && fscale != 1 {
+            let r = self.buffer.read(r_size as usize) as i32;
+            let mut dd = ((m_code.abs() - 1) << r_size) + r + 1;
+            if m_code < 0 {
+                dd = -dd;
+            }
+            d = dd;
+        } else {
+            d = m_code;
+        }
+
+        motion += d;
+        if motion > (fscale << 4) - 1 {
+            motion -= fscale << 5;
+        } else if motion < -(fscale << 4) {
+            motion += fscale << 5;
+        }
+        motion
+    }
+
+    fn predict_macroblock(&mut self) {
+        let mut fw_h = self.motion_forward.h;
+        let mut fw_v = self.motion_forward.v;
+        if self.motion_forward.full_px {
+            fw_h <<= 1;
+            fw_v <<= 1;
+        }
+
+        if self.picture_type == PICTURE_TYPE_B {
+            let mut bw_h = self.motion_backward.h;
+            let mut bw_v = self.motion_backward.v;
+            if self.motion_backward.full_px {
+                bw_h <<= 1;
+                bw_v <<= 1;
+            }
+
+            if self.motion_forward.is_set {
+                self.copy_or_interpolate_macroblock(self.fwd, fw_h, fw_v, false);
+                if self.motion_backward.is_set {
+                    self.copy_or_interpolate_macroblock(self.bwd, bw_h, bw_v, true);
+                }
+            } else {
+                self.copy_or_interpolate_macroblock(self.bwd, bw_h, bw_v, false);
+            }
+        } else {
+            self.copy_or_interpolate_macroblock(self.fwd, fw_h, fw_v, false);
+        }
+    }
+
+    fn copy_or_interpolate_macroblock(
+        &mut self,
+        src_idx: usize,
+        mh: i32,
+        mv: i32,
+        interpolate: bool,
+    ) {
+        let (mb_row, mb_col, mbw, mbh) = (self.mb_row, self.mb_col, self.mb_width, self.mb_height);
+        let cur = self.cur;
+        let (dst, src) = frame_pair(&mut self.frames, cur, src_idx);
+        process_macroblock(
+            &src.y.data,
+            &mut dst.y.data,
+            mb_row,
+            mb_col,
+            mbw,
+            mbh,
+            mh,
+            mv,
+            16,
+            interpolate,
+        );
+        process_macroblock(
+            &src.cr.data,
+            &mut dst.cr.data,
+            mb_row,
+            mb_col,
+            mbw,
+            mbh,
+            mh / 2,
+            mv / 2,
+            8,
+            interpolate,
+        );
+        process_macroblock(
+            &src.cb.data,
+            &mut dst.cb.data,
+            mb_row,
+            mb_col,
+            mbw,
+            mbh,
+            mh / 2,
+            mv / 2,
+            8,
+            interpolate,
+        );
+    }
+
+    fn decode_block(&mut self, block: i32) {
+        let mut n = 0usize;
+        let intra = self.macroblock_intra;
+
+        if intra {
+            // DC coefficient prediction.
+            let plane_index = if block > 3 { (block - 3) as usize } else { 0 };
+            let predictor = self.dc_predictor[plane_index];
+            let dct_size = self.buffer.read_vlc(dct_size_table(plane_index)) as i32;
+
+            if dct_size > 0 {
+                let differential = self.buffer.read(dct_size as usize) as i32;
+                if (differential & (1 << (dct_size - 1))) != 0 {
+                    self.block_data[0] = predictor + differential;
+                } else {
+                    self.block_data[0] = predictor + (-(1 << dct_size) | (differential + 1));
+                }
+            } else {
+                self.block_data[0] = predictor;
+            }
+
+            self.dc_predictor[plane_index] = self.block_data[0];
+            self.block_data[0] <<= 3 + 5;
+            n = 1;
+        }
+
+        let quant_matrix = if intra {
+            self.intra_quant_matrix
+        } else {
+            self.non_intra_quant_matrix
+        };
+
+        // AC coefficients (+DC for non-intra).
+        loop {
+            let coeff = self.buffer.read_vlc_uint(DCT_COEFF);
+
+            if coeff == 0x0001 && n > 0 && self.buffer.read(1) == 0 {
+                break; // end_of_block
+            }
+
+            let run: i32;
+            let mut level: i32;
+            if coeff == 0xffff {
+                // escape
+                run = self.buffer.read(6) as i32;
+                level = self.buffer.read(8) as i32;
+                if level == 0 {
+                    level = self.buffer.read(8) as i32;
+                } else if level == 128 {
+                    level = self.buffer.read(8) as i32 - 256;
+                } else if level > 128 {
+                    level -= 256;
+                }
+            } else {
+                run = (coeff >> 8) as i32;
+                level = (coeff & 0xff) as i32;
+                if self.buffer.read(1) != 0 {
+                    level = -level;
+                }
+            }
+
+            n += run as usize;
+            if n >= 64 {
+                return; // invalid
+            }
+
+            let de_zig_zagged = ZIG_ZAG[n];
+            n += 1;
+
+            // Dequantize, oddify, clip.
+            level <<= 1;
+            if !intra {
+                level += if level < 0 { -1 } else { 1 };
+            }
+            level = (level * self.quantizer_scale * quant_matrix[de_zig_zagged] as i32) >> 4;
+            if (level & 1) == 0 {
+                level -= if level > 0 { 1 } else { -1 };
+            }
+            level = level.clamp(-2048, 2047);
+
+            self.block_data[de_zig_zagged] = level * PREMULTIPLIER_MATRIX[de_zig_zagged];
+        }
+
+        // Move the block into its plane.
+        let mut s = self.block_data;
+        self.block_data = [0; 64];
+        let n_is_one = n == 1;
+        if !n_is_one {
+            idct(&mut s);
+        }
+
+        let (dw, di) = if block < 4 {
+            let mut di = (self.mb_row * self.luma_width + self.mb_col) << 4;
+            if (block & 1) != 0 {
+                di += 8;
+            }
+            if (block & 2) != 0 {
+                di += self.luma_width << 3;
+            }
+            (self.luma_width, di)
+        } else {
+            let di = ((self.mb_row * self.luma_width) << 2) + (self.mb_col << 3);
+            (self.chroma_width, di)
+        };
+
+        let cur = self.cur;
+        let frame = &mut self.frames[cur];
+        let d = if block < 4 {
+            &mut frame.y.data
+        } else if block == 4 {
+            &mut frame.cb.data
+        } else {
+            &mut frame.cr.data
+        };
+
+        if intra {
+            if n_is_one {
+                let value = clamp_u8((s[0] + 128) >> 8);
+                block_set_const(d, di, dw, value);
+            } else {
+                block_set_overwrite(d, di, dw, &s);
+            }
+        } else if n_is_one {
+            let value = (s[0] + 128) >> 8;
+            block_set_add_const(d, di, dw, value);
+        } else {
+            block_set_add(d, di, dw, &s);
+        }
+    }
+}
+
+/// Split out two distinct frames from the slice: a mutable destination and an
+/// immutable source. `dst` must not equal `src`.
+fn frame_pair(frames: &mut [Frame], dst: usize, src: usize) -> (&mut Frame, &Frame) {
+    debug_assert_ne!(dst, src);
+    if dst < src {
+        let (a, b) = frames.split_at_mut(src);
+        (&mut a[dst], &b[0])
+    } else {
+        let (a, b) = frames.split_at_mut(dst);
+        (&mut b[0], &a[src])
+    }
+}
+
+// 8x8 block writers (block source width is 8).
+fn block_set_const(d: &mut [u8], mut di: usize, dw: usize, val: u8) {
+    let dest_scan = dw - 8;
+    for _y in 0..8 {
+        for _x in 0..8 {
+            d[di] = val;
+            di += 1;
+        }
+        di += dest_scan;
+    }
+}
+
+fn block_set_overwrite(d: &mut [u8], mut di: usize, dw: usize, s: &[i32; 64]) {
+    let dest_scan = dw - 8;
+    let mut si = 0;
+    for _y in 0..8 {
+        for _x in 0..8 {
+            d[di] = clamp_u8(s[si]);
+            si += 1;
+            di += 1;
+        }
+        di += dest_scan;
+    }
+}
+
+fn block_set_add_const(d: &mut [u8], mut di: usize, dw: usize, value: i32) {
+    let dest_scan = dw - 8;
+    for _y in 0..8 {
+        for _x in 0..8 {
+            d[di] = clamp_u8(d[di] as i32 + value);
+            di += 1;
+        }
+        di += dest_scan;
+    }
+}
+
+fn block_set_add(d: &mut [u8], mut di: usize, dw: usize, s: &[i32; 64]) {
+    let dest_scan = dw - 8;
+    let mut si = 0;
+    for _y in 0..8 {
+        for _x in 0..8 {
+            d[di] = clamp_u8(d[di] as i32 + s[si]);
+            si += 1;
+            di += 1;
+        }
+        di += dest_scan;
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn process_macroblock(
+    s: &[u8],
+    d: &mut [u8],
+    mb_row: usize,
+    mb_col: usize,
+    mb_width: usize,
+    mb_height: usize,
+    motion_h: i32,
+    motion_v: i32,
+    block_size: usize,
+    interpolate: bool,
+) {
+    let dw = mb_width * block_size;
+    let hp = motion_h >> 1;
+    let vp = motion_v >> 1;
+    let odd_h = (motion_h & 1) != 0;
+    let odd_v = (motion_v & 1) != 0;
+
+    let si0 = ((mb_row * block_size) as i64 + vp as i64) * dw as i64
+        + (mb_col * block_size) as i64
+        + hp as i64;
+    let di0 = ((mb_row * dw + mb_col) * block_size) as i64;
+    let max_address = (dw * (mb_height * block_size - block_size + 1) - block_size) as i64;
+    if si0 < 0 || si0 > max_address || di0 < 0 || di0 > max_address {
+        return; // corrupt video
+    }
+
+    let mut si = si0 as usize;
+    let mut di = di0 as usize;
+    let scan = dw - block_size;
+    for _y in 0..block_size {
+        for _x in 0..block_size {
+            let val: i32 = match (interpolate, odd_h, odd_v) {
+                (false, false, false) => s[si] as i32,
+                (false, false, true) => (s[si] as i32 + s[si + dw] as i32 + 1) >> 1,
+                (false, true, false) => (s[si] as i32 + s[si + 1] as i32 + 1) >> 1,
+                (false, true, true) => {
+                    (s[si] as i32
+                        + s[si + 1] as i32
+                        + s[si + dw] as i32
+                        + s[si + dw + 1] as i32
+                        + 2)
+                        >> 2
+                }
+                (true, false, false) => (d[di] as i32 + s[si] as i32 + 1) >> 1,
+                (true, false, true) => {
+                    (d[di] as i32 + ((s[si] as i32 + s[si + dw] as i32 + 1) >> 1) + 1) >> 1
+                }
+                (true, true, false) => {
+                    (d[di] as i32 + ((s[si] as i32 + s[si + 1] as i32 + 1) >> 1) + 1) >> 1
+                }
+                (true, true, true) => {
+                    (d[di] as i32
+                        + ((s[si] as i32
+                            + s[si + 1] as i32
+                            + s[si + dw] as i32
+                            + s[si + dw + 1] as i32
+                            + 2)
+                            >> 2)
+                        + 1)
+                        >> 1
+                }
+            };
+            d[di] = val as u8;
+            si += 1;
+            di += 1;
+        }
+        si += scan;
+        di += scan;
+    }
+}
+
+fn idct(block: &mut [i32; 64]) {
+    // Transform columns.
+    for i in 0..8 {
+        let b1 = block[4 * 8 + i];
+        let b3 = block[2 * 8 + i] + block[6 * 8 + i];
+        let b4 = block[5 * 8 + i] - block[3 * 8 + i];
+        let tmp1 = block[8 + i] + block[7 * 8 + i];
+        let tmp2 = block[3 * 8 + i] + block[5 * 8 + i];
+        let b6 = block[8 + i] - block[7 * 8 + i];
+        let b7 = tmp1 + tmp2;
+        let m0 = block[i];
+        let x4 = ((b6 * 473 - b4 * 196 + 128) >> 8) - b7;
+        let x0 = x4 - (((tmp1 - tmp2) * 362 + 128) >> 8);
+        let x1 = m0 - b1;
+        let x2 = (((block[2 * 8 + i] - block[6 * 8 + i]) * 362 + 128) >> 8) - b3;
+        let x3 = m0 + b1;
+        let y3 = x1 + x2;
+        let y4 = x3 + b3;
+        let y5 = x1 - x2;
+        let y6 = x3 - b3;
+        let y7 = -x0 - ((b4 * 473 + b6 * 196 + 128) >> 8);
+        block[i] = b7 + y4;
+        block[8 + i] = x4 + y3;
+        block[2 * 8 + i] = y5 - x0;
+        block[3 * 8 + i] = y6 - y7;
+        block[4 * 8 + i] = y6 + y7;
+        block[5 * 8 + i] = x0 + y5;
+        block[6 * 8 + i] = y3 - x4;
+        block[7 * 8 + i] = y4 - b7;
+    }
+
+    // Transform rows.
+    let mut i = 0;
+    while i < 64 {
+        let b1 = block[4 + i];
+        let b3 = block[2 + i] + block[6 + i];
+        let b4 = block[5 + i] - block[3 + i];
+        let tmp1 = block[1 + i] + block[7 + i];
+        let tmp2 = block[3 + i] + block[5 + i];
+        let b6 = block[1 + i] - block[7 + i];
+        let b7 = tmp1 + tmp2;
+        let m0 = block[i];
+        let x4 = ((b6 * 473 - b4 * 196 + 128) >> 8) - b7;
+        let x0 = x4 - (((tmp1 - tmp2) * 362 + 128) >> 8);
+        let x1 = m0 - b1;
+        let x2 = (((block[2 + i] - block[6 + i]) * 362 + 128) >> 8) - b3;
+        let x3 = m0 + b1;
+        let y3 = x1 + x2;
+        let y4 = x3 + b3;
+        let y5 = x1 - x2;
+        let y6 = x3 - b3;
+        let y7 = -x0 - ((b4 * 473 + b6 * 196 + 128) >> 8);
+        block[i] = (b7 + y4 + 128) >> 8;
+        block[1 + i] = (x4 + y3 + 128) >> 8;
+        block[2 + i] = (y5 - x0 + 128) >> 8;
+        block[3 + i] = (y6 - y7 + 128) >> 8;
+        block[4 + i] = (y6 + y7 + 128) >> 8;
+        block[5 + i] = (x0 + y5 + 128) >> 8;
+        block[6 + i] = (y3 - x4 + 128) >> 8;
+        block[7 + i] = (y4 - b7 + 128) >> 8;
+        i += 8;
+    }
+}

--- a/crates/native32emu-core/tests/cutscene.rs
+++ b/crates/native32emu-core/tests/cutscene.rs
@@ -1,0 +1,64 @@
+//! End-to-end cutscene playback test. Loads EMETAL.smf, which uses
+//! SSL_PlayNext to play a logo video before the game, and verifies the
+//! emulator enters cutscene playback and renders non-black video frames.
+//!
+//! Needs the (non-distributed) game assets, so it is `#[ignore]`d:
+//!
+//! ```text
+//! cargo test -p native32emu-core --test cutscene -- --ignored --nocapture
+//! ```
+
+use std::path::PathBuf;
+
+use native32emu_core::emulator::Emulator;
+
+fn game_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("NATIVE32_GAME_DIR") {
+        let p = PathBuf::from(dir);
+        return p.is_dir().then_some(p);
+    }
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|root| root.join("native32_game"))
+        .filter(|p| p.is_dir())
+}
+
+#[test]
+#[ignore = "requires non-distributed game assets"]
+fn emetal_plays_logo_cutscene() {
+    let Some(root) = game_dir() else {
+        eprintln!("No game assets found; skipping.");
+        return;
+    };
+    let path = root.join("EPOP/EMETAL.smf");
+    if !path.is_file() {
+        eprintln!("EMETAL.smf not found; skipping.");
+        return;
+    }
+
+    let mut emu = Emulator::from_path(path, 0).expect("load EMETAL.smf");
+
+    let mut became_active = false;
+    let mut non_black = false;
+    // ~6 seconds at 30fps.
+    for _ in 0..180 {
+        emu.set_buttons(&[]);
+        if !emu.is_cutscene_active() {
+            emu.handle_buttons();
+        }
+        emu.tick();
+        emu.draw();
+        if emu.is_cutscene_active() {
+            became_active = true;
+            if emu.renderer.buffer.iter().any(|&p| (p & 0x00FF_FFFF) != 0) {
+                non_black = true;
+            }
+        }
+    }
+
+    eprintln!("became_active={became_active}, non_black={non_black}");
+    assert!(became_active, "EMETAL should enter cutscene playback");
+    assert!(non_black, "cutscene should render non-black video frames");
+}

--- a/crates/native32emu-core/tests/mpeg_demux.rs
+++ b/crates/native32emu-core/tests/mpeg_demux.rs
@@ -1,0 +1,99 @@
+//! Integration test for the MPEG-PS demuxer against a real cutscene file.
+//!
+//! Needs the (non-distributed) game assets, so it is `#[ignore]`d and run on
+//! demand:
+//!
+//! ```text
+//! cargo test -p native32emu-core --test mpeg_demux -- --ignored --nocapture
+//! ```
+//!
+//! Looks for the video under `<repo>/native32_game` by default, or override
+//! the game root with the `NATIVE32_GAME_DIR` environment variable.
+
+use std::path::PathBuf;
+
+use native32emu_core::mpeg;
+
+fn game_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("NATIVE32_GAME_DIR") {
+        let p = PathBuf::from(dir);
+        return p.is_dir().then_some(p);
+    }
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|root| root.join("native32_game"))
+        .filter(|p| p.is_dir())
+}
+
+/// Find a `.mpg` cutscene, trying the known METAL path first then any `.mpg`.
+fn find_mpg() -> Option<PathBuf> {
+    let root = game_dir()?;
+    let known = root.join("NA32SSL/ENGLISH/METAL/MSCG1.mpg");
+    if known.is_file() {
+        return Some(known);
+    }
+    // Fall back to a recursive scan for any .mpg.
+    fn scan(dir: &std::path::Path) -> Option<PathBuf> {
+        for entry in std::fs::read_dir(dir).ok()?.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                if let Some(found) = scan(&p) {
+                    return Some(found);
+                }
+            } else if p.extension().is_some_and(|e| e.eq_ignore_ascii_case("mpg")) {
+                return Some(p);
+            }
+        }
+        None
+    }
+    scan(&root)
+}
+
+#[test]
+#[ignore = "requires non-distributed .mpg assets"]
+fn demux_real_cutscene_splits_streams() {
+    let Some(path) = find_mpg() else {
+        eprintln!("No .mpg assets found; skipping.");
+        return;
+    };
+    eprintln!("Demuxing {}", path.display());
+
+    let data = std::fs::read(&path).expect("read mpg");
+    let streams = mpeg::demux_all(data);
+
+    eprintln!(
+        "video stream: {} bytes, audio stream: {} bytes (declared video={}, audio={})",
+        streams.video.len(),
+        streams.audio.len(),
+        streams.num_video_streams,
+        streams.num_audio_streams,
+    );
+
+    // The video elementary stream must be present and begin with an MPEG-1
+    // sequence header start code (00 00 01 B3).
+    assert!(
+        !streams.video.is_empty(),
+        "video stream should not be empty"
+    );
+    let seq = streams
+        .video
+        .windows(4)
+        .position(|w| w == [0x00, 0x00, 0x01, 0xB3]);
+    assert!(
+        seq.is_some(),
+        "video stream should contain a sequence header (00 00 01 B3)"
+    );
+    assert_eq!(
+        seq,
+        Some(0),
+        "video stream should start with the sequence header"
+    );
+
+    // These cutscenes carry an MP2 audio track.
+    assert!(
+        !streams.audio.is_empty(),
+        "audio stream should not be empty"
+    );
+}

--- a/crates/native32emu-core/tests/mpeg_demux.rs
+++ b/crates/native32emu-core/tests/mpeg_demux.rs
@@ -97,3 +97,39 @@ fn demux_real_cutscene_splits_streams() {
         "audio stream should not be empty"
     );
 }
+
+#[test]
+#[ignore = "requires non-distributed .mpg assets"]
+fn decode_real_cutscene_video_frames() {
+    let Some(path) = find_mpg() else {
+        eprintln!("No .mpg assets found; skipping.");
+        return;
+    };
+    eprintln!("Decoding video from {}", path.display());
+
+    let data = std::fs::read(&path).expect("read mpg");
+    let streams = mpeg::demux_all(data);
+
+    let mut video = mpeg::Video::new(streams.video);
+    assert!(video.has_header(), "should parse sequence header");
+    let (w, h) = (video.width(), video.height());
+    eprintln!("video {}x{} @ {:.3} fps", w, h, video.framerate());
+    assert!(w > 0 && h > 0, "sane dimensions");
+
+    // Decode several frames and confirm at least one is non-blank.
+    let mut frames = 0u32;
+    let mut non_blank = false;
+    while frames < 30 {
+        let Some(idx) = video.decode() else { break };
+        let frame = video.frame(idx);
+        assert_eq!(frame.width, w);
+        assert_eq!(frame.height, h);
+        if frame.y.data.iter().any(|&p| p != 0) {
+            non_blank = true;
+        }
+        frames += 1;
+    }
+    eprintln!("decoded {frames} frames, non_blank={non_blank}");
+    assert!(frames > 0, "should decode at least one frame");
+    assert!(non_blank, "decoded frames should not be entirely blank");
+}

--- a/crates/native32emu-core/tests/mpeg_demux.rs
+++ b/crates/native32emu-core/tests/mpeg_demux.rs
@@ -133,3 +133,40 @@ fn decode_real_cutscene_video_frames() {
     assert!(frames > 0, "should decode at least one frame");
     assert!(non_blank, "decoded frames should not be entirely blank");
 }
+
+#[test]
+#[ignore = "requires non-distributed .mpg assets"]
+fn decode_real_cutscene_audio_frames() {
+    let Some(path) = find_mpg() else {
+        eprintln!("No .mpg assets found; skipping.");
+        return;
+    };
+    eprintln!("Decoding audio from {}", path.display());
+
+    let data = std::fs::read(&path).expect("read mpg");
+    let streams = mpeg::demux_all(data);
+
+    let mut audio = mpeg::Audio::new(streams.audio);
+    assert!(audio.has_header(), "should parse an MP2 frame header");
+    let sr = audio.samplerate();
+    eprintln!("audio samplerate = {sr} Hz");
+    assert!(
+        [44100, 48000, 32000, 22050, 24000, 16000].contains(&sr),
+        "samplerate should be a valid MPEG audio rate"
+    );
+
+    let mut frames = 0u32;
+    let mut peak = 0.0f32;
+    while frames < 50 {
+        let Some(s) = audio.decode() else { break };
+        assert_eq!(s.interleaved.len(), 1152 * 2);
+        for &v in &s.interleaved {
+            assert!(v.is_finite(), "samples must be finite");
+            peak = peak.max(v.abs());
+        }
+        frames += 1;
+    }
+    eprintln!("decoded {frames} audio frames, peak amplitude = {peak:.4}");
+    assert!(frames > 0, "should decode at least one audio frame");
+    assert!(peak > 0.0, "decoded audio should not be pure silence");
+}

--- a/crates/native32emu-libretro/src/libretro/api.rs
+++ b/crates/native32emu-libretro/src/libretro/api.rs
@@ -214,8 +214,15 @@ pub extern "C" fn retro_run() {
         let buttons = query_joypad_buttons(0);
         emu.set_buttons(&buttons);
 
-        // 3. Handle button events (frame-based actions)
-        emu.handle_buttons();
+        // 3. Handle button events. During a cutscene, suppress game input and
+        // allow the A or B button to skip the logo/cutscene videos instead.
+        if emu.is_cutscene_active() {
+            if buttons.contains(&NATIVE32_KEY_A) || buttons.contains(&NATIVE32_KEY_B) {
+                emu.skip_cutscene();
+            }
+        } else {
+            emu.handle_buttons();
+        }
 
         // 4. Execute one tick of emulation
         emu.tick();

--- a/crates/native32emu/src/main.rs
+++ b/crates/native32emu/src/main.rs
@@ -171,7 +171,14 @@ fn main() -> Result<()> {
         // Feed keyboard state into the shared core, then run button actions
         let pressed = emu.input.get_pressed_keycodes(&window);
         emu.set_buttons(&pressed);
-        emu.handle_buttons();
+        if emu.is_cutscene_active() {
+            // Allow skipping logo/cutscene videos with the A or B button.
+            if pressed.contains(&0x4000) || pressed.contains(&0x8800) {
+                emu.skip_cutscene();
+            }
+        } else {
+            emu.handle_buttons();
+        }
 
         // Tick emulation (handles content switching internally)
         emu.tick();


### PR DESCRIPTION
Fixes #28

## Problem

Games reference full-screen MPEG-1 videos (logos / cutscenes) as the "pre-content" of `SSL_PlayNext`, but the emulator silently dropped them and jumped straight to the next SSL. For example `native32_game/EPOP/EMETAL.smf` should play `NALOGO.MPG` then `MSCG1.MPG`, etc.

## Approach

Add a **pure-Rust** MPEG-1 player by porting [PL_MPEG](https://github.com/phoboslab/pl_mpeg) (single-file, MIT) — no C dependency, no `*-sys` crate, which keeps cross-compilation (libretro/Android) simple. (OxideAV was evaluated but its MPEG-1 video crate is currently all-yanked and pre-usable, and it has no MPEG-PS container; PL_MPEG via C FFI was rejected to avoid a build-time C toolchain dependency.) The decoder lives in `native32emu-core::mpeg` so both front-ends share it.

## What's included (built incrementally)

1. **`mpeg::buffer` + `mpeg::demux`** — MSB-first bit reader and an MPEG-PS demuxer that splits a program stream into its video (0xE0) and audio (0xC0) elementary streams.
2. **`mpeg::video`** — MPEG-1 video decoder: sequence/picture/slice/macroblock parsing, all VLC tables, motion-vector reconstruction, motion compensation, dequantization and the 8×8 IDCT, producing YCrCb frames with I/P/B reordering.
3. **`mpeg::audio`** — MPEG-1 Audio Layer II (MP2) decoder: header parsing with sync recovery, bit allocation, scale factors, sample reconstruction and the 32-point subband synthesis, producing normalized interleaved stereo float PCM.
4. **Playback integration** — `SSL_PlayNext` now queues its pre-content `.mpg` videos; the emulator plays them before loading the next SSL (video scaled into the framebuffer via BT.601 YCrCb→RGB, audio handed to the audio engine), then continues to the SSL content. Both front-ends suppress game input during a cutscene and let the **A/B button skip** it; missing/invalid videos fall through.

`AudioEngine::play_pcm_stream` plays cutscene audio via rodio (standalone) or resamples into the libretro sample buffer.

## Testing

- Full `native32emu-core` suite passes (189 unit tests); clippy (`-D warnings`) and `cargo fmt --check` clean via the hooks.
- Added `#[ignore]`d integration tests (need game assets) covering: PS demux, video decode (352×288 @ 25fps, non-blank), MP2 decode (44100 Hz, non-silent), and end-to-end cutscene playback on EMETAL.smf.
- Manually ran `cargo run -p native32emu -- -f native32_game\EPOP\EMETAL.smf`: the NALOGO logo plays (320×240 screenshot is a real decoded image), then the game loads.

## Notes

- Derived from PL_MPEG; the ported files retain MIT attribution to Dominic Szablewski (compatible with this project's BSD-3-Clause).
- No new runtime dependency is added.