### PR TITLE
feat: add ZIP archive support for game packages (#31)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +236,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
  "no_std_io2",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -249,6 +275,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +291,26 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cargo-husky"
@@ -297,8 +349,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -374,6 +436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "coreaudio-rs"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +483,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -467,10 +544,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "dispatch2"
@@ -724,6 +828,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +906,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +970,15 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1175,6 +1307,7 @@ dependencies = [
  "rodio",
  "tempfile",
  "thiserror 2.0.18",
+ "zip",
 ]
 
 [[package]]
@@ -1265,6 +1398,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -1442,6 +1581,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1602,18 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1498,6 +1660,12 @@ checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1627,6 +1795,12 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1902,6 +2076,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,6 +2141,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphonia"
@@ -2172,6 +2374,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2200,6 +2421,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -2235,6 +2462,12 @@ name = "version-compare"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2813,10 +3046,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ native32-emu path/to/game.zip
 native32-emu --fullscreen game.smf
 ```
 
+**ZIP mode**: When loading from a `.zip` file, the emulator starts the FHUI
+menu. Selecting a game launches it; pressing **ESC** during gameplay returns to
+the menu. Pressing ESC on the menu itself exits the emulator. When loading a
+`.smf` file directly, ESC exits as usual.
+
 ### RetroArch Mode
 
 Native32Emu can be used as a libretro core with RetroArch, allowing you to play Native32 games with RetroArch's features like shaders, netplay, and achievements.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Native32 is a game format developed by Sunplus for DVD player and TV chipsets (c
 - **Sprite/movie system** — animation, cloning, visibility control, depth-sorted rendering
 - **Audio playback** — MP3 music and raw 16-bit PCM sound effects
 - **MPEG-1 cutscenes** — pure-Rust MPEG-1 video + MP2 audio decoder plays `SSL_PlayNext` logo/cutscene videos (no C dependency); skippable with A/B
+- **ZIP archive support** — load game packages directly from `.zip` files (auto-extracts and loads FHUI.smf)
 - **Keyboard input** — configurable key remapping
 - **Save system** — `.ssl_sav` file persistence
 - **SSL multi-file content** — seamless switching between game levels/files
@@ -40,6 +41,9 @@ The basic usage is list below, but there are many more options for controlling t
 # Basic usage
 native32-emu path/to/game.smf
 
+# Load from ZIP archive (auto-extracts and loads FHUI.smf)
+native32-emu path/to/game.zip
+
 # Fullscreen mode
 native32-emu --fullscreen game.smf
 ```
@@ -55,7 +59,7 @@ Native32Emu can be used as a libretro core with RetroArch, allowing you to play 
 3. **Load the core in RetroArch**:
    - Open RetroArch
    - Select "Load Core" → "Native32 (Native32Emu)"
-   - Select "Load Content" and choose a `.smf`, `.sgm`, or `.ssl` game file
+   - Select "Load Content" and choose a `.smf`, `.sgm`, `.ssl`, or `.zip` game file
 
 #### RetroArch on Android
 
@@ -68,7 +72,7 @@ for install and build instructions.
 - ✅ Video output (XRGB8888 pixel format)
 - ✅ Audio output (RAW PCM, stereo)
 - ✅ Input handling (D-Pad + A/B buttons)
-- ✅ Game loading (.smf, .sgm, .ssl files)
+- ✅ Game loading (.smf, .sgm, .ssl, .zip files)
 - ⚠️ MP3 audio (not yet implemented — only RAW PCM works)
 - ❌ Save states (not yet implemented)
 - ❌ Core options (not yet implemented)

--- a/crates/native32emu-core/Cargo.toml
+++ b/crates/native32emu-core/Cargo.toml
@@ -15,6 +15,8 @@ thiserror.workspace = true
 log.workspace = true
 rand.workspace = true
 image.workspace = true
+zip = "0.6"  # ZIP archive extraction for game packages
+tempfile = "3"  # Temporary directory management for ZIP extraction
 
 # Only needed by the standalone front-end's audio/input code paths.
 minifb = { workspace = true, optional = true }

--- a/crates/native32emu-core/src/archive_loader.rs
+++ b/crates/native32emu-core/src/archive_loader.rs
@@ -1,0 +1,268 @@
+// Archive loader for ZIP game packages.
+//
+// Native32 games are distributed as ZIP archives containing a complete game
+// directory structure with FHUI.smf (main menu) and game subdirectories.
+// This module handles extraction and locating the entry-point SMF file.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Extract a ZIP archive to a temporary directory and return the path.
+///
+/// The caller is responsible for cleaning up the returned directory when done.
+pub fn extract_zip(zip_path: &Path) -> Result<PathBuf> {
+    let file = fs::File::open(zip_path)
+        .with_context(|| format!("Failed to open ZIP file: {}", zip_path.display()))?;
+
+    let mut archive = zip::ZipArchive::new(file)
+        .with_context(|| format!("Failed to read ZIP archive: {}", zip_path.display()))?;
+
+    // Create a temporary directory for extraction
+    let temp_dir =
+        tempfile::tempdir().context("Failed to create temporary directory for ZIP extraction")?;
+    let extract_path = temp_dir.keep();
+
+    // Extract all files from the archive
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .with_context(|| format!("Failed to read ZIP entry at index {}", i))?;
+
+        let outpath = extract_path.join(file.mangled_name());
+
+        // Skip directories (they'll be created as needed)
+        if file.name().ends_with('/') {
+            fs::create_dir_all(&outpath)
+                .with_context(|| format!("Failed to create directory: {}", outpath.display()))?;
+            continue;
+        }
+
+        // Create parent directories if needed
+        if let Some(parent) = outpath.parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent).with_context(|| {
+                    format!("Failed to create parent directory: {}", parent.display())
+                })?;
+            }
+        }
+
+        // Extract the file
+        let mut outfile = fs::File::create(&outpath)
+            .with_context(|| format!("Failed to create file: {}", outpath.display()))?;
+        std::io::copy(&mut file, &mut outfile)
+            .with_context(|| format!("Failed to extract file: {}", outpath.display()))?;
+    }
+
+    Ok(extract_path)
+}
+
+/// Find the FHUI.smf (main menu) file in an extracted directory.
+///
+/// Searches for FHUI.smf in the root of the extracted directory, handling
+/// case-insensitive matching. Returns the path if found, or None if not found.
+pub fn find_fhui_in_directory(dir: &Path) -> Option<PathBuf> {
+    // Try exact match first
+    let fhui_path = dir.join("FHUI.smf");
+    if fhui_path.exists() {
+        return Some(fhui_path);
+    }
+
+    // Try case-insensitive match
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if name_str.eq_ignore_ascii_case("FHUI.smf") {
+                return Some(entry.path());
+            }
+        }
+    }
+
+    None
+}
+
+/// Process a ZIP file: extract it and find the FHUI.smf entry point.
+///
+/// Returns the path to the extracted FHUI.smf file, or an error if:
+/// - The ZIP cannot be extracted
+/// - No FHUI.smf is found in the archive
+pub fn load_zip_game(zip_path: &Path) -> Result<PathBuf> {
+    log::info!("Extracting ZIP archive: {}", zip_path.display());
+
+    let extract_path = extract_zip(zip_path)?;
+
+    // Find FHUI.smf in the extracted directory
+    match find_fhui_in_directory(&extract_path) {
+        Some(fhui_path) => {
+            log::info!("Found FHUI.smf: {}", fhui_path.display());
+            Ok(fhui_path)
+        }
+        None => {
+            // Clean up the temporary directory
+            let _ = fs::remove_dir_all(&extract_path);
+            anyhow::bail!("No FHUI.smf found in ZIP archive: {}", zip_path.display());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_extract_zip_empty_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        let zip_path = dir.path().join("test.zip");
+
+        // Create an empty ZIP file
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        zip.finish().unwrap();
+
+        let result = extract_zip(&zip_path);
+        assert!(result.is_ok());
+
+        // Clean up
+        let _ = fs::remove_dir_all(result.unwrap());
+    }
+
+    #[test]
+    fn test_extract_zip_with_fhui() {
+        let dir = tempfile::tempdir().unwrap();
+        let zip_path = dir.path().join("test.zip");
+
+        // Create a ZIP with FHUI.smf
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+        zip.start_file("FHUI.smf", options).unwrap();
+        zip.write_all(b"fake smf content").unwrap();
+        zip.finish().unwrap();
+
+        let result = extract_zip(&zip_path);
+        assert!(result.is_ok());
+
+        let extract_path = result.unwrap();
+        assert!(extract_path.join("FHUI.smf").exists());
+
+        // Clean up
+        let _ = fs::remove_dir_all(extract_path);
+    }
+
+    #[test]
+    fn test_find_fhui_exact_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let fhui_path = dir.path().join("FHUI.smf");
+        fs::write(&fhui_path, b"fake").unwrap();
+
+        let result = find_fhui_in_directory(dir.path());
+        assert_eq!(result, Some(fhui_path));
+    }
+
+    #[test]
+    fn test_find_fhui_case_insensitive() {
+        let dir = tempfile::tempdir().unwrap();
+        let fhui_path = dir.path().join("fhui.smf");
+        fs::write(&fhui_path, b"fake").unwrap();
+
+        let result = find_fhui_in_directory(dir.path());
+        assert!(result.is_some());
+        // The path should exist and have the correct filename (case may vary)
+        let result_path = result.unwrap();
+        assert!(result_path.exists());
+        assert_eq!(
+            result_path
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_lowercase(),
+            "fhui.smf"
+        );
+    }
+
+    #[test]
+    fn test_find_fhui_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("other.smf"), b"fake").unwrap();
+
+        let result = find_fhui_in_directory(dir.path());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_load_zip_game_with_fhui() {
+        let dir = tempfile::tempdir().unwrap();
+        let zip_path = dir.path().join("game.zip");
+
+        // Create a ZIP with FHUI.smf
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+        zip.start_file("FHUI.smf", options).unwrap();
+        zip.write_all(b"fake smf content").unwrap();
+        zip.finish().unwrap();
+
+        let result = load_zip_game(&zip_path);
+        assert!(result.is_ok());
+
+        let fhui_path = result.unwrap();
+        assert!(fhui_path.exists());
+        assert_eq!(fhui_path.file_name().unwrap().to_str().unwrap(), "FHUI.smf");
+
+        // Clean up
+        let _ = fs::remove_dir_all(fhui_path.parent().unwrap());
+    }
+
+    #[test]
+    fn test_load_zip_game_no_fhui() {
+        let dir = tempfile::tempdir().unwrap();
+        let zip_path = dir.path().join("game.zip");
+
+        // Create a ZIP without FHUI.smf
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+        zip.start_file("other.smf", options).unwrap();
+        zip.write_all(b"fake smf content").unwrap();
+        zip.finish().unwrap();
+
+        let result = load_zip_game(&zip_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_zip_game_with_subdirectory() {
+        let dir = tempfile::tempdir().unwrap();
+        let zip_path = dir.path().join("game.zip");
+
+        // Create a ZIP with nested structure (FHUI.smf in root, not in subdirectory)
+        let file = fs::File::create(&zip_path).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let options =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+        // Add FHUI.smf in root (typical structure)
+        zip.start_file("FHUI.smf", options).unwrap();
+        zip.write_all(b"fake smf content").unwrap();
+        // Add a subdirectory with game files
+        zip.add_directory("EACT/", options).unwrap();
+        zip.start_file("EACT/GAME.smf", options).unwrap();
+        zip.write_all(b"fake game content").unwrap();
+        zip.finish().unwrap();
+
+        let result = load_zip_game(&zip_path);
+        assert!(result.is_ok());
+
+        // Clean up
+        let _ = fs::remove_dir_all(result.unwrap().parent().unwrap());
+    }
+}

--- a/crates/native32emu-core/src/archive_loader.rs
+++ b/crates/native32emu-core/src/archive_loader.rs
@@ -10,8 +10,9 @@ use std::path::{Path, PathBuf};
 
 /// Extract a ZIP archive to a temporary directory and return the path.
 ///
-/// The caller is responsible for cleaning up the returned directory when done.
-pub fn extract_zip(zip_path: &Path) -> Result<PathBuf> {
+/// The `TempDir` handle is returned alongside the path so the caller can keep
+/// it alive — the directory is automatically deleted when the handle is dropped.
+pub fn extract_zip(zip_path: &Path) -> Result<(tempfile::TempDir, PathBuf)> {
     let file = fs::File::open(zip_path)
         .with_context(|| format!("Failed to open ZIP file: {}", zip_path.display()))?;
 
@@ -21,7 +22,7 @@ pub fn extract_zip(zip_path: &Path) -> Result<PathBuf> {
     // Create a temporary directory for extraction
     let temp_dir =
         tempfile::tempdir().context("Failed to create temporary directory for ZIP extraction")?;
-    let extract_path = temp_dir.keep();
+    let extract_path = temp_dir.path().to_path_buf();
 
     // Extract all files from the archive
     for i in 0..archive.len() {
@@ -54,7 +55,7 @@ pub fn extract_zip(zip_path: &Path) -> Result<PathBuf> {
             .with_context(|| format!("Failed to extract file: {}", outpath.display()))?;
     }
 
-    Ok(extract_path)
+    Ok((temp_dir, extract_path))
 }
 
 /// Find the FHUI.smf (main menu) file in an extracted directory.
@@ -84,23 +85,22 @@ pub fn find_fhui_in_directory(dir: &Path) -> Option<PathBuf> {
 
 /// Process a ZIP file: extract it and find the FHUI.smf entry point.
 ///
-/// Returns the path to the extracted FHUI.smf file, or an error if:
-/// - The ZIP cannot be extracted
-/// - No FHUI.smf is found in the archive
-pub fn load_zip_game(zip_path: &Path) -> Result<PathBuf> {
+/// Returns the `TempDir` handle (keep it alive to preserve the directory) and
+/// the path to the extracted FHUI.smf file. The directory is automatically
+/// deleted when the `TempDir` is dropped.
+pub fn load_zip_game(zip_path: &Path) -> Result<(tempfile::TempDir, PathBuf)> {
     log::info!("Extracting ZIP archive: {}", zip_path.display());
 
-    let extract_path = extract_zip(zip_path)?;
+    let (temp_dir, extract_path) = extract_zip(zip_path)?;
 
     // Find FHUI.smf in the extracted directory
     match find_fhui_in_directory(&extract_path) {
         Some(fhui_path) => {
             log::info!("Found FHUI.smf: {}", fhui_path.display());
-            Ok(fhui_path)
+            Ok((temp_dir, fhui_path))
         }
         None => {
-            // Clean up the temporary directory
-            let _ = fs::remove_dir_all(&extract_path);
+            // temp_dir is dropped here, automatically cleaning up the directory
             anyhow::bail!("No FHUI.smf found in ZIP archive: {}", zip_path.display());
         }
     }
@@ -123,9 +123,7 @@ mod tests {
 
         let result = extract_zip(&zip_path);
         assert!(result.is_ok());
-
-        // Clean up
-        let _ = fs::remove_dir_all(result.unwrap());
+        // TempDir cleans up automatically when dropped
     }
 
     #[test]
@@ -146,11 +144,9 @@ mod tests {
         let result = extract_zip(&zip_path);
         assert!(result.is_ok());
 
-        let extract_path = result.unwrap();
+        let (_temp_dir, extract_path) = result.unwrap();
         assert!(extract_path.join("FHUI.smf").exists());
-
-        // Clean up
-        let _ = fs::remove_dir_all(extract_path);
+        // TempDir cleans up automatically when dropped
     }
 
     #[test]
@@ -212,12 +208,10 @@ mod tests {
         let result = load_zip_game(&zip_path);
         assert!(result.is_ok());
 
-        let fhui_path = result.unwrap();
+        let (_temp_dir, fhui_path) = result.unwrap();
         assert!(fhui_path.exists());
         assert_eq!(fhui_path.file_name().unwrap().to_str().unwrap(), "FHUI.smf");
-
-        // Clean up
-        let _ = fs::remove_dir_all(fhui_path.parent().unwrap());
+        // TempDir cleans up automatically when dropped
     }
 
     #[test]
@@ -261,8 +255,6 @@ mod tests {
 
         let result = load_zip_game(&zip_path);
         assert!(result.is_ok());
-
-        // Clean up
-        let _ = fs::remove_dir_all(result.unwrap().parent().unwrap());
+        // TempDir cleans up automatically when dropped
     }
 }

--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -46,9 +46,19 @@ pub struct Emulator {
 
 impl Emulator {
     /// Create a new emulator from a game file path.
+    ///
+    /// Supports .smf, .sgm, .ssl, and .zip files. For .zip files, extracts
+    /// the archive and loads FHUI.smf (main menu) from the extracted directory.
     pub fn from_path(path: PathBuf, volume: u32) -> Result<Self> {
-        let data = std::fs::read(&path)
-            .with_context(|| format!("Failed to read game file: {}", path.display()))?;
+        // Check if this is a ZIP file
+        let game_path = if is_zip_file(&path) {
+            crate::archive_loader::load_zip_game(&path)?
+        } else {
+            path
+        };
+
+        let data = std::fs::read(&game_path)
+            .with_context(|| format!("Failed to read game file: {}", game_path.display()))?;
 
         let mut reader = Native32Reader::new(data);
         reader.init().context("Failed to initialize game file")?;
@@ -56,10 +66,10 @@ impl Emulator {
         let resolution = reader.resolution;
         let colorspace = reader.colorspace;
 
-        let save_manager = SaveManager::new(&path);
+        let save_manager = SaveManager::new(&game_path);
 
         Ok(Self {
-            filename: path,
+            filename: game_path,
             reader,
             sprites: SpriteSystem::new(),
             frame_player: FramePlayer::new(),
@@ -865,4 +875,26 @@ fn normalize_content_path(filename: &str) -> String {
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("/")
+}
+
+/// Check if a file is a ZIP archive by reading its magic bytes.
+///
+/// ZIP files start with "PK\x03\x04" (local file header signature).
+fn is_zip_file(path: &PathBuf) -> bool {
+    // First check the extension
+    if let Some(ext) = path.extension() {
+        if ext.to_string_lossy().eq_ignore_ascii_case("zip") {
+            return true;
+        }
+    }
+
+    // Fallback: check magic bytes
+    if let Ok(mut file) = std::fs::File::open(path) {
+        let mut magic = [0u8; 4];
+        if std::io::Read::read_exact(&mut file, &mut magic).is_ok() {
+            return magic == [0x50, 0x4B, 0x03, 0x04]; // PK\x03\x04
+        }
+    }
+
+    false
 }

--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -46,6 +46,9 @@ pub struct Emulator {
     /// Set to None when the user loaded a game directly (not from a menu).
     /// Used to support "return to menu" on ESC.
     pub initial_file: Option<PathBuf>,
+    /// Temporary directory handle for ZIP extraction. When this field is
+    /// dropped (e.g. when the Emulator is dropped), the directory is deleted.
+    _temp_dir: Option<tempfile::TempDir>,
 }
 
 impl Emulator {
@@ -56,10 +59,11 @@ impl Emulator {
     pub fn from_path(path: PathBuf, volume: u32) -> Result<Self> {
         // Check if this is a ZIP file
         let is_zip = is_zip_file(&path);
-        let game_path = if is_zip {
-            crate::archive_loader::load_zip_game(&path)?
+        let (game_path, _temp_dir) = if is_zip {
+            let (td, p) = crate::archive_loader::load_zip_game(&path)?;
+            (p, Some(td))
         } else {
-            path
+            (path, None)
         };
 
         let data = std::fs::read(&game_path)
@@ -100,6 +104,7 @@ impl Emulator {
             pending_videos: Vec::new(),
             video_player: None,
             initial_file,
+            _temp_dir,
         })
     }
 

--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -42,6 +42,10 @@ pub struct Emulator {
     pub pending_videos: Vec<String>,
     /// Active cutscene player, if a video is currently playing.
     pub video_player: Option<crate::mpeg::VideoPlayer>,
+    /// The initial file loaded at startup (typically FHUI.smf from a ZIP).
+    /// Set to None when the user loaded a game directly (not from a menu).
+    /// Used to support "return to menu" on ESC.
+    pub initial_file: Option<PathBuf>,
 }
 
 impl Emulator {
@@ -51,7 +55,8 @@ impl Emulator {
     /// the archive and loads FHUI.smf (main menu) from the extracted directory.
     pub fn from_path(path: PathBuf, volume: u32) -> Result<Self> {
         // Check if this is a ZIP file
-        let game_path = if is_zip_file(&path) {
+        let is_zip = is_zip_file(&path);
+        let game_path = if is_zip {
             crate::archive_loader::load_zip_game(&path)?
         } else {
             path
@@ -67,6 +72,14 @@ impl Emulator {
         let colorspace = reader.colorspace;
 
         let save_manager = SaveManager::new(&game_path);
+
+        // When loaded from a ZIP, remember the FHUI.smf path so pressing ESC
+        // in a game returns to the menu instead of exiting.
+        let initial_file = if is_zip {
+            Some(game_path.clone())
+        } else {
+            None
+        };
 
         Ok(Self {
             filename: game_path,
@@ -86,6 +99,7 @@ impl Emulator {
             time_ms: 0,
             pending_videos: Vec::new(),
             video_player: None,
+            initial_file,
         })
     }
 
@@ -100,6 +114,43 @@ impl Emulator {
             crate::file_loader::Colorspace::YUV => 11025.0,
             crate::file_loader::Colorspace::ARGB => 22050.0,
         }
+    }
+
+    /// Whether the emulator can return to an initial menu (e.g. FHUI.smf).
+    /// Returns true only when an initial menu file was set (ZIP mode) and the
+    /// current file is different (i.e. we are in a game, not already on the menu).
+    pub fn can_return_to_menu(&self) -> bool {
+        self.initial_file
+            .as_ref()
+            .is_some_and(|p| *p != self.filename)
+    }
+
+    /// Reload the emulator from the given file path, performing a full state
+    /// reset. Preserves `initial_file` so the user can return to the menu again.
+    pub fn reload_from_path(&mut self, path: PathBuf) -> Result<()> {
+        let data = std::fs::read(&path)
+            .with_context(|| format!("Failed to read game file: {}", path.display()))?;
+
+        self.audio.stop_all();
+        self.renderer.clear_sprite_overrides();
+        self.pending_videos.clear();
+        self.video_player = None;
+        self.tick_count = 0;
+        self.time_ms = 0;
+        self.sprites = SpriteSystem::new();
+        self.frame_player = FramePlayer::new();
+        self.vm = ActionVM::new();
+        self.content_loader = ContentLoader::new();
+        self.cur_frame_objects.clear();
+        self.menu_context = None;
+
+        self.filename = path;
+        self.reader = Native32Reader::new(data);
+        self.reader.init()?;
+        self.audio = AudioEngine::new(self.reader.colorspace, (self.audio.volume * 100.0) as u32);
+        self.save_manager = SaveManager::new(&self.filename);
+
+        Ok(())
     }
 
     /// Set button state from libretro input.

--- a/crates/native32emu-core/src/lib.rs
+++ b/crates/native32emu-core/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod action_vm;
 pub mod actions;
+pub mod archive_loader;
 pub mod audio_engine;
 pub mod content_loader;
 pub mod dat_loader;

--- a/crates/native32emu-core/tests/smoke.rs
+++ b/crates/native32emu-core/tests/smoke.rs
@@ -356,3 +356,60 @@ fn fhui_menu_starts_selected_game() {
         "selecting a game did not launch it: still on the menu"
     );
 }
+
+/// Test ZIP file loading: a ZIP archive containing FHUI.smf should be extracted
+/// and the main menu loaded automatically.
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn zip_file_loads_fhui() {
+    let dir = match game_dir() {
+        Some(d) => d,
+        None => {
+            eprintln!("skipping: no game directory found (set NATIVE32_GAME_DIR)");
+            return;
+        }
+    };
+
+    // Look for a ZIP file in the parent directory (tmp/native32_game.zip)
+    let zip_path = dir
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|root| root.join("tmp").join("native32_game.zip"))
+        .filter(|p| p.exists());
+
+    let zip_path = match zip_path {
+        Some(p) => p,
+        None => {
+            eprintln!("skipping: native32_game.zip not found");
+            return;
+        }
+    };
+
+    // Load the ZIP file
+    let mut emu = Emulator::from_path(zip_path, 100).expect("failed to load ZIP game");
+
+    // Verify that FHUI.smf was loaded (the main menu)
+    let name = emu
+        .filename
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        name.eq_ignore_ascii_case("FHUI.smf"),
+        "expected FHUI.smf to be loaded from ZIP, but got: {name}"
+    );
+
+    // Run a few frames to ensure it's functional
+    for _ in 0..30 {
+        emu.set_buttons(&[]);
+        emu.handle_buttons();
+        emu.tick();
+        emu.draw();
+    }
+
+    assert!(
+        frame_has_content(emu.get_framebuffer()),
+        "ZIP-loaded FHUI.smf produced a blank frame"
+    );
+}

--- a/crates/native32emu/src/main.rs
+++ b/crates/native32emu/src/main.rs
@@ -164,8 +164,29 @@ fn main() -> Result<()> {
     // Main emulation loop
     let mut frame_count: u32 = 0;
     let screenshot_path = cli.screenshot.clone();
+    // Debounce counter: after returning to menu via ESC, suppress further ESC
+    // detections for a few frames so the key release is not re-triggered.
+    let mut esc_cooldown: u32 = 0;
 
-    while window.is_open() && !window.is_key_down(minifb::Key::Escape) {
+    while window.is_open() {
+        // Handle ESC key: return to menu (ZIP mode) or exit.
+        if esc_cooldown > 0 {
+            esc_cooldown -= 1;
+        } else if window.is_key_down(minifb::Key::Escape) {
+            if emu.can_return_to_menu() {
+                if let Some(menu_path) = emu.initial_file.clone() {
+                    if let Err(e) = emu.reload_from_path(menu_path) {
+                        log::error!("Failed to reload menu: {}", e);
+                        break;
+                    }
+                }
+                esc_cooldown = 15; // ~0.5s at 30fps, enough for key release
+                continue;
+            } else {
+                break;
+            }
+        }
+
         let frame_start = Instant::now();
 
         // Feed keyboard state into the shared core, then run button actions

--- a/crates/native32emu/src/standalone/cli.rs
+++ b/crates/native32emu/src/standalone/cli.rs
@@ -8,7 +8,9 @@ use std::path::PathBuf;
 #[command(about = "A Native32 game emulator written in Rust")]
 #[command(version)]
 pub struct Cli {
-    /// Path to the game file (.smf, .sgm, or .ssl)
+    /// Path to the game file (.smf, .sgm, .ssl, or .zip)
+    ///
+    /// For .zip files, extracts the archive and loads FHUI.smf (main menu).
     pub game_path: Option<PathBuf>,
 
     /// Integer scaling factor (1-16)

--- a/docs/CLI-Options.md
+++ b/docs/CLI-Options.md
@@ -20,7 +20,7 @@ native32-emu [OPTIONS] <GAME_PATH>
 
 | Option | Value | Default | Description |
 |---|---|---|---|
-| `<GAME_PATH>` | path | *required* | Path to the game file (`.smf`, `.sgm`, or `.ssl`). |
+| `<GAME_PATH>` | path | *required* | Path to the game file (`.smf`, `.sgm`, `.ssl`, or `.zip`). For `.zip` files, extracts and loads FHUI.smf automatically. |
 | `-s, --scale <N>` | `1`–`16` | `1` | Integer scaling factor for the window. |
 | `-f, --fullscreen` | flag | off | Run in borderless fullscreen at the desktop resolution. |
 | `-v, --volume <N>` | `0`–`100` | `100` | Volume level (`0` = mute, `100` = original). |
@@ -103,6 +103,9 @@ first repeat arrives.
 ```bash
 # Basic usage
 native32-emu path/to/game.smf
+
+# Load from ZIP archive (auto-extracts and loads FHUI.smf)
+native32-emu path/to/game.zip
 
 # 2x scaling with 80% volume
 native32-emu --scale 2 --volume 80 path/to/game.smf


### PR DESCRIPTION
## Summary

Closes #31.

Adds support for loading Native32 game packages directly from `.zip` files. The emulator extracts the archive to a temporary directory and loads `FHUI.smf` (main menu). When playing a game launched from the menu, pressing ESC returns to the menu instead of exiting — matching the behavior of the original hardware.

## Problem

Native32 games are distributed as ZIP archives containing a complete directory structure (`FHUI.smf` + category subdirectories + individual games). Users had to manually extract these before launching the emulator.

## Solution

### ZIP archive loading

- New `archive_loader` module handles ZIP extraction (via the `zip` crate) to a temporary directory and locates `FHUI.smf` in the extracted contents.
- `Emulator::from_path` detects ZIP files by extension or magic bytes (`PK\x03\x04`) and transparently extracts them before loading.
- If no `FHUI.smf` is found in the archive, the operation fails with a clear error.
- The temporary directory is automatically cleaned up when the `Emulator` is dropped.

### ESC returns to menu (ZIP mode only)

- `Emulator` tracks the initial menu file via `initial_file: Option<PathBuf>` — set automatically when loading from a ZIP.
- `can_return_to_menu()` returns true only when a menu file was set and the user is currently in a game (not already on the menu).
- `reload_from_path()` performs a full state reset and reloads the target file, preserving `initial_file` so the user can return to the menu again.
- The main loop uses a debounce counter to prevent ESC re-trigger while the key is held.
- Direct `.smf` loading is unaffected — ESC exits as before.

## Changes

- `crates/native32emu-core/src/archive_loader.rs` — New module: ZIP extraction and FHUI.smf discovery
- `crates/native32emu-core/src/emulator.rs` — ZIP detection in `from_path`, `initial_file` field, `can_return_to_menu()`, `reload_from_path()`
- `crates/native32emu-core/src/lib.rs` — Register `archive_loader` module
- `crates/native32emu-core/Cargo.toml` — Add `zip` and `tempfile` dependencies
- `crates/native32emu/src/main.rs` — Conditional ESC handling (return to menu or exit) with debounce
- `crates/native32emu/src/standalone/cli.rs` — Update help text to list `.zip` as supported
- `crates/native32emu-core/tests/smoke.rs` — Integration test for ZIP loading
- `README.md` — Add ZIP support to features, usage examples, and ESC behavior note
- `docs/CLI-Options.md` — Update CLI options documentation

## Notes for reviewer

- ISO file support is deferred to a future PR.