### PR TITLE
Declare .zip support in the libretro core

### DIFF
--- a/crates/native32emu-libretro/native32emu_libretro.info
+++ b/crates/native32emu-libretro/native32emu_libretro.info
@@ -1,7 +1,7 @@
 # Software Information
 display_name = "Native32 (Native32Emu)"
 authors = "Aloys"
-supported_extensions = "smf|sgm|ssl"
+supported_extensions = "smf|sgm|ssl|zip"
 corename = "native32emu"
 categories = "Emulator"
 license = "BSD-3-Clause"
@@ -29,4 +29,4 @@ needs_fullpath = "true"
 disk_control = "false"
 is_experimental = "true"
 
-description = "Native32Emu is an emulator for the Native32 game format developed by Sunplus for DVD player and TV chipsets. This libretro core supports .smf, .sgm and .ssl content. Audio is currently limited to RAW PCM (MP3 music is not yet played); save states and core options are not implemented."
+description = "Native32Emu is an emulator for the Native32 game format developed by Sunplus for DVD player and TV chipsets. This libretro core supports .smf, .sgm and .ssl content, as well as .zip game packages (extracted automatically, booting the FHUI.smf menu). Audio is currently limited to RAW PCM (MP3 music is not yet played); save states and core options are not implemented."

--- a/crates/native32emu-libretro/src/libretro/api.rs
+++ b/crates/native32emu-libretro/src/libretro/api.rs
@@ -94,9 +94,12 @@ pub extern "C" fn retro_get_system_info(info: *mut retro_system_info) {
         (*info) = retro_system_info {
             library_name: c"Native32Emu".as_ptr(),
             library_version: c"0.1.0".as_ptr(),
-            valid_extensions: c"smf|sgm|ssl".as_ptr(),
+            valid_extensions: c"smf|sgm|ssl|zip".as_ptr(),
             need_fullpath: true,
-            block_extract: false,
+            // A .zip is a complete Native32 game package; the core extracts it
+            // itself and boots FHUI.smf, so RetroArch must hand over the whole
+            // archive rather than auto-extracting and passing an inner file.
+            block_extract: true,
         };
     }
 }


### PR DESCRIPTION
## Summary

Declares `.zip` support in the libretro core so RetroArch can load Native32 game packages directly. The core engine (`native32emu-core`) already extracts `.zip` archives and boots `FHUI.smf`, but the libretro front-end did not advertise the extension, so RetroArch never handed `.zip` files to the core.

## Changes

- **`api.rs`** — `retro_get_system_info`:
  - `valid_extensions`: `smf|sgm|ssl` → `smf|sgm|ssl|zip`
  - `block_extract`: `false` → `true`, so RetroArch passes the whole archive to the core (which extracts it and boots the FHUI.smf menu) instead of auto-extracting and passing an inner file.
- **`native32emu_libretro.info`** — `supported_extensions` adds `zip`; description mentions `.zip` package support.

## Why

`retro_load_game` calls `Emulator::from_path`, which detects `.zip`, extracts to a temp dir, and loads `FHUI.smf` (with ESC → return-to-menu). Without `zip` in `valid_extensions` + `block_extract = true`, RetroArch would extract the archive itself and pass an inner `.smf`, bypassing the core's menu logic. This change makes the RetroArch behavior match what the README already documents.

## Follow-up

The same info file is already merged into `libretro-super` (PR #1982). A separate PR will update `dist/info/native32emu_libretro.info` there to keep `supported_extensions` in sync. Tracked in #20.

## Verification

- `cargo build -p native32emu-libretro --release` passes.
- pre-commit (clippy/fmt) hook passed.

Refs jiangxincode/Native32Emu#20