### PR TITLE
Set is_experimental to false in native32emu info

### DIFF
--- a/crates/native32emu-libretro/native32emu_libretro.info
+++ b/crates/native32emu-libretro/native32emu_libretro.info
@@ -27,6 +27,6 @@ load_subsystem = "false"
 hw_render = "false"
 needs_fullpath = "true"
 disk_control = "false"
-is_experimental = "true"
+is_experimental = "false"
 
 description = "Native32Emu is an emulator for the Native32 game format developed by Sunplus for DVD player and TV chipsets. This libretro core supports .smf, .sgm and .ssl content, as well as .zip game packages (extracted automatically, booting the FHUI.smf menu)."


### PR DESCRIPTION
## Summary

Sets `is_experimental = "false"` in `crates/native32emu-libretro/native32emu_libretro.info`.

## Why

With `is_experimental = "true"`:
- The core is hidden in RetroArch's Core Downloader unless the user enables **Online Updater > Update Settings > Show experimental cores**.
- The information RetroArch displays for the core is misleading.

The core is functional and now live on the buildbot, so it should be listed as a regular (non-experimental) core.

## Follow-up

The same field is mirrored in the merged `libretro-super` info file; a separate PR updates it there to keep them in sync.

Closes #42