### PR TITLE
feat: enable auto-generated release notes in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,7 @@ jobs:
         with:
           draft: true
           prerelease: false
+          generate_release_notes: true
           name: "Native32 Emulator ${{ github.ref_name }}"
           body: |
             Native32 Emulator ${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -135,13 +135,6 @@ RetroArch's `cores/` directory.
 
 For Android cross-compilation, see [Android Libretro Core](docs/Android-Libretro-Core.md).
 
-#### Distributing via RetroArch's Online Updater
-
-Work to make the core installable directly from RetroArch (Online Updater > Core
-Downloader) — the buildbot recipe, the `libretro-super` info file, documentation,
-and their current status — is tracked in
-[issue #20](https://github.com/jiangxincode/Native32Emu/issues/20).
-
 ## Testing
 
 Run the unit tests:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Native32 is a game format developed by Sunplus for DVD player and TV chipsets (c
 
 Download the latest binary from the [Releases](https://github.com/jiangxincode/Native32Emu/releases) page.
 
-The basic usage is list below, but there are many more options for controlling the behavior of the emulator. See the [Command-line Options](docs/CLI-Options.md) documentation for the full list of options.
+The basic usage is listed below, but there are many more options for controlling the behavior of the emulator. See the [Command-line Options](docs/CLI-Options.md) documentation for the full list of options.
 
 ```bash
 # Basic usage

--- a/crates/native32emu-core/src/action_vm.rs
+++ b/crates/native32emu-core/src/action_vm.rs
@@ -448,10 +448,6 @@ mod tests {
 
     // === Helper functions ===
 
-    fn parse_float(s: &str) -> f64 {
-        s.parse::<f64>().unwrap_or(0.0)
-    }
-
     /// Mock VmHost that records calls for verification.
     struct MockHost {
         stopped: bool,

--- a/crates/native32emu-core/src/image_decoder.rs
+++ b/crates/native32emu-core/src/image_decoder.rs
@@ -289,10 +289,6 @@ fn argb1555_to_argb(value: u16) -> u32 {
     }
 }
 
-fn read_u16_le(data: &[u8], offset: usize) -> u16 {
-    u16::from_le_bytes([data[offset], data[offset + 1]])
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/native32emu-core/src/lib.rs
+++ b/crates/native32emu-core/src/lib.rs
@@ -5,7 +5,6 @@
 // windowing or audio output device; the front-ends (the standalone binary and
 // the libretro core) link against this crate and add the platform layer.
 
-#![allow(dead_code)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::manual_memcpy)]
 #![allow(clippy::needless_range_loop)]

--- a/crates/native32emu-libretro/src/lib.rs
+++ b/crates/native32emu-libretro/src/lib.rs
@@ -5,7 +5,6 @@
 // (no post-build renaming required). All emulation logic lives in the shared
 // `native32emu` core crate; this crate only implements the libretro C API.
 
-#![allow(dead_code)]
 #![allow(clippy::upper_case_acronyms)]
 
 pub mod libretro;

--- a/docs/Android-Libretro-Core.md
+++ b/docs/Android-Libretro-Core.md
@@ -31,6 +31,6 @@ cargo ndk -t arm64-v8a -t armeabi-v7a -t x86 -t x86_64 -p 21 \
   build -p native32emu-libretro --release
 ```
 
-Each ABI produces `libnative32emu_libretro.so`; rename it to
+Each ABI produces `libnative32emu.so`; rename it to
 `native32emu_libretro_android.so` when installing into RetroArch on Android.
 The CI release workflow performs this packaging automatically.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,7 +12,6 @@
 
 - **Game compatibility testing** — test more games and report issues with screenshots
 - **VM opcode implementation** — some rare opcodes are not yet fully implemented
-- **Audio/video support** — `.mpg` video playback is not yet supported
 - **Platform ports** — macOS and Linux testing and packaging
 - **Documentation** — improve docs and code comments
 - **Bug reports** — if you find a game that doesn't work correctly, please open an issue

--- a/docs/Game-Compatibility.md
+++ b/docs/Game-Compatibility.md
@@ -31,8 +31,8 @@ All 84 Native32 games in the test suite load and run without fatal errors. Each 
 | 1 | 加 21 | Adding 21 | tmp/native32_game/EELA/Adding21.smf | ![加21](images/EELA/Adding21.png) | 数学加法练习游戏，通过趣味互动学习加法运算。 | ✅ Pass |
 | 2 | 字母排序 | Alphabetical Order | tmp/native32_game/EELA/AlpOrder.smf | ![字母排序](images/EELA/AlpOrder.png) | 字母排序学习游戏，练习英文字母的正确顺序。 | ✅ Pass |
 | 3 | 动物朋友 | Animal Friends | tmp/native32_game/EELA/AnimalFr.smf | ![动物朋友](images/EELA/AnimalFr.png) | 动物认知学习游戏，认识各种动物朋友。 | ✅ Pass |
-| 4 | 动物一 | Animals 1 | tmp/native32_game/EELA/Animals1.smf | ![动物一](images/EELA/Animals1.png) | 水果认知学习游戏（第二辑），通过图片认识各种水果。 | ✅ Pass |
-| 5 | 动物二 | Animals 2 | tmp/native32_game/EELA/Animals2.smf | ![动物二](images/EELA/Animals2.png) | 水果认知学习游戏，通过图片认识各种水果。 | ✅ Pass |
+| 4 | 动物一 | Animals 1 | tmp/native32_game/EELA/Animals1.smf | ![动物一](images/EELA/Animals1.png) | 动物认知学习游戏，通过图片认识各种动物。 | ✅ Pass |
+| 5 | 动物二 | Animals 2 | tmp/native32_game/EELA/Animals2.smf | ![动物二](images/EELA/Animals2.png) | 动物认知学习游戏（第二辑），认识更多种类的动物。 | ✅ Pass |
 | 6 | 小鸡回家 | Chicklin | tmp/native32_game/EELA/Chicklin.smf | ![小鸡回家](images/EELA/Chicklin.png) | 关于简单加减乘除运算正误判断的练习，适合多个年龄层幼儿，判断数学等式是否正确。 | ✅ Pass |
 | 7 | 颜色魔法 | Colors Magic | tmp/native32_game/EELA/ColorsMa.smf | ![颜色魔法](images/EELA/ColorsMa.png) | 颜色配对学习游戏，通过匹配颜色学习辨识不同色彩。 | ✅ Pass |
 | 8 | 阅读理解 | Comprehension | tmp/native32_game/EELA/Comprehe.smf | ![阅读理解](images/EELA/Comprehe.png) | 阅读理解练习游戏，通过阅读短文回答问题，提升阅读能力。 | ✅ Pass |

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -1,0 +1,132 @@
+# Release Process
+
+This document describes how to publish a new release of Native32Emu.
+
+## Prerequisites
+
+- Push access to the `master` branch
+- Permission to create tags and releases on GitHub
+
+## Steps
+
+### 1. Update version numbers
+
+Version numbers must be updated in **two files**:
+
+| File | Field | Current |
+|------|-------|---------|
+| `Cargo.toml` (workspace root) | `[workspace.package] version` | `"0.1.0"` |
+| `crates/native32emu-libretro/native32emu_libretro.info` | `display_version` | `"0.1.0"` |
+
+Both values must match. The `.info` file is copied directly into the release
+artifacts — RetroArch reads `display_version` to display the core version to
+users.
+
+```bash
+# Example: bumping to 0.2.0
+# 1. Edit Cargo.toml
+sed -i 's/^version = "0.1.0"/version = "0.2.0"/' Cargo.toml
+
+# 2. Edit .info file
+sed -i 's/^display_version = "0.1.0"/display_version = "0.2.0"/' \
+  crates/native32emu-libretro/native32emu_libretro.info
+```
+
+### 2. Commit the version bump
+
+```bash
+git add Cargo.toml Cargo.lock crates/native32emu-libretro/native32emu_libretro.info
+git commit -m "chore: bump version to 0.2.0"
+git push origin master
+```
+
+### 3. Create and push a tag
+
+The release workflow triggers on tags matching `v*` (e.g. `v0.2.0`).
+
+```bash
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+### 4. CI builds and creates a draft release
+
+Pushing the tag triggers `.github/workflows/release.yml`, which:
+
+1. **Builds standalone binaries** for Linux, macOS (x86_64 + aarch64), and Windows
+2. **Builds libretro cores** for the same platforms, renaming the cdylib to
+   `native32emu_libretro.<ext>` and bundling `native32emu_libretro.info`
+3. **Builds the Android libretro core** for `arm64-v8a`, `armeabi-v7a`, `x86`,
+   `x86_64`, packaged as `native32-emu-android-libretro.tar.gz`
+4. **Creates a draft GitHub Release** with:
+   - Auto-generated release notes (PRs and commits since the previous tag)
+   - A download table for standalone, libretro, and Android artifacts
+   - All build artifacts attached
+
+### 5. Review and publish the release
+
+1. Go to [Releases](https://github.com/jiangxincode/Native32Emu/releases)
+2. Find the draft release created by CI
+3. Review the auto-generated changelog — edit if needed
+4. Verify all expected artifacts are attached:
+   - `native32-emu-linux-x86_64.tar.gz`
+   - `native32-emu-macos-x86_64.tar.gz`
+   - `native32-emu-macos-aarch64.tar.gz`
+   - `native32-emu-windows-x86_64.zip`
+   - `*-libretro.*` (one per platform)
+   - `native32-emu-android-libretro.tar.gz`
+5. Click **Publish release**
+
+### 6. Sync `.info` file to upstream libretro-super
+
+RetroArch's **Online Updater > Core Downloader** reads the `.info` file from the
+upstream [libretro-super](https://github.com/libretro/libretro-super) repository
+(`dist/info/native32emu_libretro.info`), not from this repo. If the `.info` file
+was changed in this release (version, metadata, supported extensions, etc.), a
+PR must be submitted to sync the changes upstream.
+
+1. Fork [libretro/libretro-super](https://github.com/libretro/libretro-super)
+2. Copy `crates/native32emu-libretro/native32emu_libretro.info` from this repo
+   to `dist/info/native32emu_libretro.info` in the fork
+3. Submit a PR to `libretro/libretro-super` — reference the Native32Emu release
+   tag and list the changed fields in the PR description
+4. Some detailed infomation can be found in:
+   [#20](https://github.com/jiangxincode/Native32Emu/issues/20) (Distribute the libretro core via RetroArch Online Updater)
+
+## Troubleshooting
+
+### CI build fails
+
+- Check the [Actions](https://github.com/jiangxincode/Native32Emu/actions) tab
+  for the failed run
+- The most common failure is a missing Linux build dependency — the CI installs
+  `libasound2-dev`, `libx11-dev`, and `libxkbcommon-dev` automatically
+
+### Re-triggering a release
+
+The release workflow only runs on tag pushes. To re-trigger:
+
+```bash
+# 1. Delete the tag locally and remotely
+git tag -d v0.2.0
+git push origin --delete v0.2.0
+
+# 2. Re-push the tag (CI will re-run)
+git push origin v0.2.0
+```
+
+If a draft release was already created by the failed run, delete it from the
+[Releases](https://github.com/jiangxincode/Native32Emu/releases) page before
+re-pushing the tag, otherwise the new run may conflict with the existing draft.
+
+### Release artifacts missing
+
+- Verify the tag name starts with `v` (e.g. `v0.2.0`, not `0.2.0`)
+- The release workflow only triggers on tag pushes (`v*`); manually dispatching
+  the workflow from the Actions tab will not create a release
+
+### Version mismatch in RetroArch
+
+- Ensure both `Cargo.toml` and `native32emu_libretro.info` have the same
+  version string
+- The `.info` file is bundled as-is into the release artifacts


### PR DESCRIPTION
## Changes

### 1. Enable auto-generated release notes
Add `generate_release_notes: true` to `softprops/action-gh-release` so that changelogs are automatically generated from merged PRs and commits between tags, appended below the existing manual description (Downloads section).

### 2. Remove blanket `#![allow(dead_code)]` and clean up dead code
- Remove crate-level `#![allow(dead_code)]` from both `native32emu-core` and `native32emu-libretro` so that dead code warnings surface naturally.
- Delete unused `read_u16_le()` in `image_decoder.rs` (superseded by `read_u16_le_slice()`).
- Delete unused `parse_float()` helper in `action_vm.rs` test module (only visible under `--all-targets`, caused CI clippy failure).

### 3. Remove outdated MPEG-1 claim from CONTRIBUTING.md
The "Areas That Need Help" section stated ".mpg video playback is not yet supported", which is stale — MPEG-1 video + MP2 audio decoding is fully implemented in the `mpeg/` module. Removed the outdated item.

### 4. Fix grammar in README.md
Fix "The basic usage is list below" → "is listed below".

### 5. Fix incorrect Android build output filename in docs
`cargo ndk` produces `libnative32emu.so`, not `libnative32emu_libretro.so`. Corrected the filename in `Android-Libretro-Core.md`.

### 6. Remove `workflow_dispatch` from release workflow
Manual dispatch builds all artifacts but never creates a release (the `release` job requires a tag). This silently wastes CI minutes. Removed the trigger entirely.

### 7. Add release process documentation
New `docs/Release-Process.md` covering version bump, tag push, CI build, draft release review, re-triggering failed releases, and upstream `.info` sync to `libretro/libretro-super`.

### 8. Remove duplicate Online Updater section from README
The "Distributing via RetroArch's Online Updater" section in README duplicated content now covered in `docs/Release-Process.md`. Removed to avoid maintaining two copies.

### 9. Fix Animals 1/2 copy-paste error in Game-Compatibility.md
Animals 1 and Animals 2 had descriptions copied from the Fruits entries ("水果认知学习游戏"). Corrected to "动物认知学习游戏".