### PR TITLE
fix: restore Magical Adventure mini-game progression

### DIFF
--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -191,6 +191,7 @@ impl Emulator {
         // of the normal timeline.
         if self.is_cutscene_active() {
             self.cutscene_tick();
+            self.time_ms += 1000 / 30;
             return;
         }
 
@@ -314,6 +315,8 @@ impl Emulator {
             }
         }
 
+        self.handle_buttons();
+
         // Handle content switching (SSL_PlayNext)
         if self.content_loader.has_pending() && !self.is_cutscene_active() {
             if let Some(filename) = self.content_loader.take_pending() {
@@ -322,6 +325,8 @@ impl Emulator {
                 }
             }
         }
+
+        self.time_ms += 1000 / 30;
     }
 
     /// Whether a cutscene video is currently playing or queued.

--- a/crates/native32emu-core/src/sprite_system.rs
+++ b/crates/native32emu-core/src/sprite_system.rs
@@ -63,14 +63,31 @@ impl SpriteSystem {
         for obj in frame_objects {
             if obj.obj_type == crate::file_loader::ObjectType::Movie {
                 if let Some(ref name) = obj.name {
-                    frame_movie_names.insert(name.clone());
-                    if !self.sprites.contains_key(name) {
-                        // Create new movie instance
-                        let mut state = MovieState::new(obj.index as u32, obj.x, obj.y, obj.depth);
-                        state.next_frame = Some(0);
-                        self.sprites.insert(name.clone(), state);
+                    if self.sprites.contains_key(name) {
+                        frame_movie_names.insert(name.clone());
+                    } else {
+                        let renamed_instance = self
+                            .sprites
+                            .iter()
+                            .find(|(_, movie)| {
+                                !movie.cloned
+                                    && movie.movie == obj.index as u32
+                                    && movie.depth == obj.depth
+                            })
+                            .map(|(existing_name, _)| existing_name.clone());
+
+                        if let Some(existing_name) = renamed_instance {
+                            frame_movie_names.insert(existing_name);
+                        } else {
+                            // Create new movie instance.
+                            let mut state =
+                                MovieState::new(obj.index as u32, obj.x, obj.y, obj.depth);
+                            state.next_frame = Some(0);
+                            self.sprites.insert(name.clone(), state);
+                            frame_movie_names.insert(name.clone());
+                        }
                     }
-                    // If already exists, preserve its state (don't reset)
+                    // If already exists, preserve its state (do not reset).
                 }
             }
         }
@@ -236,6 +253,23 @@ mod tests {
         let movie = ss.get("hero").unwrap();
         assert_eq!(movie.frame, 42, "frame should be preserved");
         assert!(!movie.visible, "visibility should be preserved");
+    }
+
+    #[test]
+    fn test_update_for_frame_preserves_renamed_instances_by_identity() {
+        let mut ss = SpriteSystem::new();
+        let objects = vec![make_movie_object("q0n0", 7, 10, 20, 3)];
+        ss.update_for_frame(&objects);
+
+        let mut renamed = ss.remove("q0n0").unwrap();
+        renamed.y = -124;
+        ss.insert("qn0".to_string(), renamed);
+
+        ss.update_for_frame(&objects);
+
+        assert!(ss.contains_key("qn0"));
+        assert!(!ss.contains_key("q0n0"));
+        assert_eq!(ss.get("qn0").unwrap().y, -124);
     }
 
     #[test]

--- a/crates/native32emu-core/tests/cutscene.rs
+++ b/crates/native32emu-core/tests/cutscene.rs
@@ -45,9 +45,6 @@ fn emetal_plays_logo_cutscene() {
     // ~6 seconds at 30fps.
     for _ in 0..180 {
         emu.set_buttons(&[]);
-        if !emu.is_cutscene_active() {
-            emu.handle_buttons();
-        }
         emu.tick();
         emu.draw();
         if emu.is_cutscene_active() {

--- a/crates/native32emu-core/tests/smoke.rs
+++ b/crates/native32emu-core/tests/smoke.rs
@@ -134,7 +134,6 @@ fn run_one(path: &Path) -> Result<bool, String> {
 
     for _ in 0..FRAMES {
         emu.set_buttons(&[]);
-        emu.handle_buttons();
         emu.tick();
         emu.draw();
     }
@@ -183,7 +182,6 @@ where
     for frame in 0..frames {
         let pressed = input_for_frame(frame);
         emu.set_buttons(&pressed);
-        emu.handle_buttons();
         emu.tick();
         emu.draw();
     }
@@ -357,6 +355,66 @@ fn fhui_menu_starts_selected_game() {
     );
 }
 
+/// Regression test for Magical Adventure's first mini-game flow: a confirm
+/// press must be consumed by the mini-game script after the frame actions run,
+/// starting the timer instead of leaving the prompt stuck forever.
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn magical_adventure_minigame_confirm_starts_timer() {
+    let dir = match game_dir() {
+        Some(d) => d,
+        None => {
+            eprintln!("skipping: no game directory found (set NATIVE32_GAME_DIR)");
+            return;
+        }
+    };
+    let game = match find_asset(&dir, "MagicalA.smf") {
+        Some(p) => p,
+        None => {
+            eprintln!("skipping: MagicalA.smf not found under {}", dir.display());
+            return;
+        }
+    };
+
+    let mut emu = Emulator::from_path(game, 100).expect("load Magical Adventure");
+
+    for frame in 0..540 {
+        if frame == 240 {
+            emu.vm.vars.insert("gamestate".into(), "2".into());
+            emu.vm.vars.insert("mgstate".into(), "0".into());
+            emu.vm.vars.insert("mgkind".into(), "0".into());
+            emu.vm.vars.insert("mglevel".into(), "0".into());
+            emu.vm.vars.insert("mgenemy".into(), "0".into());
+            emu.vm.vars.insert("loopstep".into(), "0".into());
+            emu.vm.vars.insert("mgstep".into(), "0".into());
+            emu.vm.vars.insert("oldkeypad".into(), "0".into());
+            emu.vm.vars.insert("icount".into(), "0".into());
+        }
+
+        let pressed = if (80..83).contains(&frame)
+            || (220..223).contains(&frame)
+            || (285..288).contains(&frame)
+        {
+            vec![KEY_Z]
+        } else {
+            vec![]
+        };
+        emu.set_buttons(&pressed);
+        emu.tick();
+        emu.draw();
+    }
+
+    let timebar_frame = emu.sprites.get("timeBar").map(|m| m.frame).unwrap_or(0);
+    assert!(
+        timebar_frame > 0,
+        "mini-game timer did not advance after confirm (timeBar frame = {timebar_frame})"
+    );
+    assert!(
+        emu.vm.vars.get("mgstate").is_some_and(|v| v != "0"),
+        "mini-game stayed in init state after confirm: {:?}",
+        emu.vm.vars.get("mgstate")
+    );
+}
 /// Test ZIP file loading: a ZIP archive containing FHUI.smf should be extracted
 /// and the main menu loaded automatically.
 #[test]
@@ -403,7 +461,6 @@ fn zip_file_loads_fhui() {
     // Run a few frames to ensure it's functional
     for _ in 0..30 {
         emu.set_buttons(&[]);
-        emu.handle_buttons();
         emu.tick();
         emu.draw();
     }

--- a/crates/native32emu-libretro/src/libretro/api.rs
+++ b/crates/native32emu-libretro/src/libretro/api.rs
@@ -228,18 +228,15 @@ pub extern "C" fn retro_run() {
         let buttons = query_joypad_buttons(0);
         emu.set_buttons(&buttons);
 
-        // 3. Handle button events. During a cutscene, suppress game input and
+        // 3. During a cutscene, suppress game input and
         // allow the A or B button to skip the logo/cutscene videos instead.
         // When auto-skip is enabled, skip as soon as the cutscene starts.
-        if emu.is_cutscene_active() {
-            if emu.auto_skip_cutscenes
+        if emu.is_cutscene_active()
+            && (emu.auto_skip_cutscenes
                 || buttons.contains(&NATIVE32_KEY_A)
-                || buttons.contains(&NATIVE32_KEY_B)
-            {
-                emu.skip_cutscene();
-            }
-        } else {
-            emu.handle_buttons();
+                || buttons.contains(&NATIVE32_KEY_B))
+        {
+            emu.skip_cutscene();
         }
 
         // 4. Execute one tick of emulation
@@ -262,9 +259,6 @@ pub extern "C" fn retro_run() {
                 audio_samples.len() / 2, // Stereo: 2 samples per frame
             );
         }
-
-        // 8. Update time
-        emu.time_ms += 1000 / 30;
     }
 }
 

--- a/crates/native32emu/src/main.rs
+++ b/crates/native32emu/src/main.rs
@@ -193,17 +193,15 @@ fn main() -> Result<()> {
 
         let frame_start = Instant::now();
 
-        // Feed keyboard state into the shared core, then run button actions
+        // Feed keyboard state into the shared core; tick consumes button actions
         let pressed = emu.input.get_pressed_keycodes(&window);
         emu.set_buttons(&pressed);
-        if emu.is_cutscene_active() {
-            // Allow skipping logo/cutscene videos with the A or B button, or
-            // automatically when auto-skip is enabled.
-            if emu.auto_skip_cutscenes || pressed.contains(&0x4000) || pressed.contains(&0x8800) {
-                emu.skip_cutscene();
-            }
-        } else {
-            emu.handle_buttons();
+        // Allow skipping logo/cutscene videos with the A or B button, or
+        // automatically when auto-skip is enabled.
+        if emu.is_cutscene_active()
+            && (emu.auto_skip_cutscenes || pressed.contains(&0x4000) || pressed.contains(&0x8800))
+        {
+            emu.skip_cutscene();
         }
 
         // Tick emulation (handles content switching internally)
@@ -233,8 +231,6 @@ fn main() -> Result<()> {
             )
             .context("Failed to update display")?;
 
-        // Update time
-        emu.time_ms += 1000 / 30;
         frame_count += 1;
 
         // Take screenshot if requested


### PR DESCRIPTION
## Summary

Fixes the Magical Adventure first mini-game flow reported in #50. The mini-game now consumes confirm input at the correct point in the frame, keeps the renamed falling-number sprites alive across timeline refreshes, and allows the timer/object logic to continue instead of freezing.

This PR addresses only the mini-game progression part of #50. The audio slowdown mentioned in the same issue is intentionally left open for separate investigation.

## Root Cause

The mini-game progression bug had two interacting causes:

1. Front-ends called `handle_buttons()` before `Emulator::tick()`. Some Native32 games, including Magical Adventure, run frame actions before checking keypad state and clear keypad state inside those actions. Processing input outside the core meant the mini-game script observed input on the wrong frame/order.
2. Magical Adventure renames movie instances with `SetProperty(Name)` from names such as `q0n0` to runtime names such as `qn0`. On the next main timeline frame refresh, `SpriteSystem::update_for_frame()` only retained instances whose current name still appeared in the frame object list. That removed the renamed runtime sprites, so later `SetProperty(qn0, Y, ...)` calls had no live sprite to update. Visually, the falling numbers stayed stuck and the mini-game could not progress normally.

## Solution

- Move button consumption into `Emulator::tick()` after frame/movie actions have run, matching the core emulation order for standalone, libretro, and tests.
- Move `time_ms` advancement into `Emulator::tick()` so timing is consistent across all front-ends.
- Remove duplicate front-end/test calls to `handle_buttons()` and front-end-owned `time_ms` updates.
- Teach `SpriteSystem::update_for_frame()` to preserve a renamed non-cloned movie instance when it still matches the same source movie/depth identity in the refreshed frame.
- Add regression coverage for renamed movie instances and the Magical Adventure mini-game timer/input flow.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test -p native32emu-core sprite_system::tests::test_update_for_frame_preserves_renamed_instances_by_identity`
- `$env:NATIVE32_GAME_DIR='E:\Code\Native32Emu\tmp\native32_game'; cargo test -p native32emu-core --test smoke magical_adventure_minigame_confirm_starts_timer -- --ignored --nocapture`
- Manual verification with `E:\Code\Native32Emu\tmp\native32_game\EELA\MagicalA.smf`: the first mini-game now starts correctly and the falling numbers/timer progress.

Related to #50
