### PR TITLE
fix: preserve YUV raw audio duration

### DIFF
--- a/crates/native32emu-core/src/file_loader.rs
+++ b/crates/native32emu-core/src/file_loader.rs
@@ -491,7 +491,7 @@ impl Native32Reader {
                 // Big-endian to little-endian conversion
                 SoundData {
                     format: AudioFormat::Raw,
-                    data: endian_swap_resample(raw_data),
+                    data: endian_swap_pcm16(raw_data),
                 }
             } else {
                 SoundData {
@@ -576,11 +576,12 @@ fn parse_resolution(gen_str: &str) -> Option<(u32, u32)> {
     None
 }
 
-fn endian_swap_resample(data: &[u8]) -> Vec<u8> {
+fn endian_swap_pcm16(data: &[u8]) -> Vec<u8> {
     let len = data.len() & 0xFFFFFFFE;
-    let mut result = vec![0u8; len * 2];
-    for i in 0..(2 * len) {
-        result[i] = data[(2 * (i / 4)) | ((i & 0x1) ^ 0x1)];
+    let mut result = vec![0u8; len];
+    for (out, input) in result.chunks_exact_mut(2).zip(data[..len].chunks_exact(2)) {
+        out[0] = input[1];
+        out[1] = input[0];
     }
     result
 }
@@ -623,45 +624,40 @@ mod tests {
         assert_eq!(parse_resolution("Resolution_0_0"), Some((0, 0)));
     }
 
-    // === endian_swap_resample tests ===
+    // === endian_swap_pcm16 tests ===
 
     #[test]
-    fn test_endian_swap_resample_two_bytes() {
-        // 2 bytes [0x12, 0x34] → 4 bytes with endian swap
+    fn test_endian_swap_pcm16_two_bytes() {
+        // 2 bytes [0x12, 0x34] stay 2 bytes with endian swap
         let input = vec![0x12, 0x34];
-        let output = endian_swap_resample(&input);
-        assert_eq!(output.len(), 4);
-        // The algorithm doubles the data and swaps bytes within each 16-bit sample
-        // Original: [0x12, 0x34] → pairs: (0x12, 0x34)
-        // Output: swap within pair → [0x34, 0x12, 0x34, 0x12]
-        assert_eq!(output, vec![0x34, 0x12, 0x34, 0x12]);
+        let output = endian_swap_pcm16(&input);
+        assert_eq!(output.len(), 2);
+        assert_eq!(output, vec![0x34, 0x12]);
     }
 
     #[test]
-    fn test_endian_swap_resample_four_bytes() {
+    fn test_endian_swap_pcm16_four_bytes() {
         let input = vec![0xAA, 0xBB, 0xCC, 0xDD];
-        let output = endian_swap_resample(&input);
-        assert_eq!(output.len(), 8);
+        let output = endian_swap_pcm16(&input);
+        assert_eq!(output.len(), 4);
         // Pairs: (0xAA, 0xBB), (0xCC, 0xDD)
-        // Each pair gets endian-swapped and doubled:
-        // [0xBB, 0xAA, 0xBB, 0xAA, 0xDD, 0xCC, 0xDD, 0xCC]
-        assert_eq!(output, vec![0xBB, 0xAA, 0xBB, 0xAA, 0xDD, 0xCC, 0xDD, 0xCC]);
+        assert_eq!(output, vec![0xBB, 0xAA, 0xDD, 0xCC]);
     }
 
     #[test]
-    fn test_endian_swap_resample_empty() {
-        let output = endian_swap_resample(&[]);
+    fn test_endian_swap_pcm16_empty() {
+        let output = endian_swap_pcm16(&[]);
         assert!(output.is_empty());
     }
 
     #[test]
-    fn test_endian_swap_resample_odd_length() {
+    fn test_endian_swap_pcm16_odd_length() {
         // Odd length: last byte is ignored (len & 0xFFFFFFFE)
         let input = vec![0x12, 0x34, 0x56];
-        let output = endian_swap_resample(&input);
-        // len = 2 (0x56 ignored), result = 2 * 2 = 4 bytes
-        assert_eq!(output.len(), 4);
-        assert_eq!(output, vec![0x34, 0x12, 0x34, 0x12]);
+        let output = endian_swap_pcm16(&input);
+        // len = 2 (0x56 ignored)
+        assert_eq!(output.len(), 2);
+        assert_eq!(output, vec![0x34, 0x12]);
     }
 
     // === ObjectType::from_u16 tests ===


### PR DESCRIPTION
## Summary

Fixes the audio slowdown part of #50 by preserving the original duration of YUV raw PCM samples. This PR is scoped only to the sound-speed issue; the Magical Adventure mini-game progression bug is handled separately in #53.

## Problem

Native32 raw sound data is documented as 16-bit mono PCM. In YUV files, the raw PCM samples are big-endian and played at 11025 Hz. The Rust loader converted YUV raw audio with `endian_swap_resample()`, which both swapped bytes and duplicated every 16-bit sample. Because the Rust audio paths already report/play YUV raw audio at 11025 Hz, duplicating the samples doubled the sample count and stretched playback to twice the original duration. That made game audio sound slow, matching the remaining symptom reported in #50.

The older Python prototype initialized pygame's mixer at 22050 Hz, so duplicating 11025 Hz samples there acted like a crude upsample. The Rust standalone and libretro paths do not need that conversion because their YUV output rate is already 11025 Hz.

## Solution

Replace the YUV raw audio conversion with a pure 16-bit PCM endian swap:

- Keep the sample count unchanged.
- Convert each big-endian 16-bit sample to little-endian for Rust playback.
- Continue ignoring a trailing odd byte, as before.
- Update unit tests to assert that conversion preserves byte length and only swaps each 16-bit pair.

## Changes

- `crates/native32emu-core/src/file_loader.rs` — renamed `endian_swap_resample` to `endian_swap_pcm16`, removed sample duplication, and updated the PCM endian-swap tests.

## Verification

- `cargo test -p native32emu-core file_loader::tests::test_endian_swap_pcm16` ✓
- `cargo fmt --all -- --check` ✓
- `git diff --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo test --workspace` ✓
- `git push` pre-push hook: `cargo test --all` ✓
- Manual verification with `E:\Code\Native32Emu\tmp\native32_game\EELA\MagicalA.smf`: audio speed sounded normal.

Related to #50
