### PR TITLE
docs: remove irrelevant MP3 support notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ for install and build instructions.
 - ✅ Audio output (RAW PCM, stereo)
 - ✅ Input handling (D-Pad + A/B buttons)
 - ✅ Game loading (.smf, .sgm, .ssl, .zip files)
-- ⚠️ MP3 audio (not yet implemented — only RAW PCM works)
 - ❌ Save states (not yet implemented)
 - ✅ Core options (audio volume, key auto-repeat timing, swap A/B, auto-skip cutscenes)
 
@@ -105,7 +104,6 @@ auto-repeat timing, swap A/B, auto-skip cutscenes). See
 #### Audio Notes
 
 - **RAW PCM**: Fully supported (11025Hz for YUV games, 22050Hz for ARGB games)
-- **MP3**: Not yet supported in libretro mode (games using MP3 will have no music)
 - Audio is output as stereo (mono sources are duplicated to both channels)
 
 ## Building

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,7 +15,7 @@
 - **Platform ports** — macOS and Linux testing and packaging
 - **Documentation** — improve docs and code comments
 - **Bug reports** — if you find a game that doesn't work correctly, please open an issue
-- **RetroArch integration** — MP3 audio support, save states, core options
+- **RetroArch integration** — save states
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

- remove the unsupported MP3 warning from the RetroArch feature list
- remove the MP3 limitation from the audio notes
- remove MP3 support from the contributor task list

The bundled Native32 game corpus uses RAW PCM resources, so these notices do not describe an issue affecting the known games.

## Validation

- cargo fmt -- --check
- cargo clippy -- -D warnings
- cargo test --all