### PR TITLE
fix: restore looping MP3 music playback (#50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,6 +1327,7 @@ dependencies = [
  "rodio",
  "serde",
  "serde_json",
+ "symphonia",
  "tempfile",
  "thiserror 2.0.18",
  "zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ image = "0.25"            # Image processing
 clap = { version = "4", features = ["derive"] }  # CLI argument parsing (standalone)
 minifb = "0.28"           # Window creation and pixel rendering (standalone)
 rodio = { version = "0.22", features = ["mp3"] }  # Audio playback, MP3 + PCM (standalone)
+symphonia = { version = "0.5.5", default-features = false, features = ["mp3"] }  # Pure-Rust MP3 decoding
 env_logger = "0.11"       # Log output to stderr (standalone)
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ for install and build instructions.
 #### Supported Features
 
 - ✅ Video output (XRGB8888 pixel format)
-- ✅ Audio output (RAW PCM, stereo)
+- ✅ Audio output (looping MP3 music mixed with RAW PCM sound effects, stereo)
 - ✅ Input handling (D-Pad + A/B buttons)
 - ✅ Game loading (.smf, .sgm, .ssl, .zip files)
 - ✅ Save states
@@ -103,6 +103,7 @@ auto-repeat timing, swap A/B, auto-skip cutscenes). See
 
 #### Audio Notes
 
+- **MP3**: Fully supported, including finite/infinite loops and simultaneous sound effects
 - **RAW PCM**: Fully supported (11025Hz for YUV games, 22050Hz for ARGB games)
 - Audio is output as stereo (mono sources are duplicated to both channels)
 

--- a/crates/native32emu-core/Cargo.toml
+++ b/crates/native32emu-core/Cargo.toml
@@ -17,6 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 crc32fast.workspace = true
 image.workspace = true
+symphonia.workspace = true
 zip = "8.6"  # ZIP archive extraction for game packages
 tempfile = "3"  # Temporary directory management for ZIP extraction
 

--- a/crates/native32emu-core/src/audio_engine.rs
+++ b/crates/native32emu-core/src/audio_engine.rs
@@ -1,11 +1,18 @@
 // Audio engine: handles MP3 and raw PCM audio playback.
 
 use crate::file_loader::{AudioFormat, Colorspace, Native32Reader};
+#[cfg(not(feature = "standalone"))]
+use symphonia::core::{
+    audio::SampleBuffer, codecs::DecoderOptions, errors::Error as SymphoniaError,
+    formats::FormatOptions, io::MediaSourceStream, meta::MetadataOptions, probe::Hint,
+};
 
 #[cfg(feature = "standalone")]
 use rodio::Source;
 #[cfg(feature = "standalone")]
 use std::num::NonZero;
+
+const MAX_SOUND_EFFECTS: usize = 8;
 
 pub struct AudioEngine {
     // Standalone mode: rodio audio
@@ -14,25 +21,88 @@ pub struct AudioEngine {
     #[cfg(feature = "standalone")]
     mixer: Option<rodio::mixer::Mixer>,
     #[cfg(feature = "standalone")]
-    player: Option<rodio::Player>,
+    music_player: Option<StandaloneChannel>,
+    #[cfg(feature = "standalone")]
+    sound_players: Vec<StandaloneChannel>,
 
     pub volume: f32,
     pub colorspace: Colorspace,
-    // Track which movie owns the currently playing sound
-    pub music_owner: Option<String>,
+    next_channel_id: usize,
+    sample_frame_remainder: u32,
 
-    // Libretro mode: pending audio samples buffer
-    pending_samples: Vec<i16>,
-    // Simple tone generator for testing
+    #[cfg(not(feature = "standalone"))]
+    channels: Vec<PlaybackChannel>,
     tone_phase: f64,
     tone_active: bool,
+}
+
+#[cfg(feature = "standalone")]
+struct StandaloneChannel {
+    id: usize,
+    owner: String,
+    player: rodio::Player,
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+enum SavedAudioSource {
+    Mp3(Vec<u8>),
+    Raw(Vec<u8>),
+    DecodedPcm(Vec<i16>),
+}
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct SavedChannel {
+    id: usize,
+    owner: String,
+    source: SavedAudioSource,
+    position: usize,
+    loops_remaining: Option<u32>,
+    is_music: bool,
+}
+
+#[cfg(not(feature = "standalone"))]
+struct PlaybackChannel {
+    state: SavedChannel,
+    samples: Vec<i16>,
+    finished: bool,
+}
+
+#[cfg(not(feature = "standalone"))]
+impl PlaybackChannel {
+    fn next_frame(&mut self) -> Option<(i16, i16)> {
+        loop {
+            if self.state.position * 2 < self.samples.len() {
+                let offset = self.state.position * 2;
+                self.state.position += 1;
+                return Some((self.samples[offset], self.samples[offset + 1]));
+            }
+            if self.samples.is_empty() {
+                self.finished = true;
+                return None;
+            }
+            match self.state.loops_remaining {
+                Some(remaining) if remaining > 0 => {
+                    self.state.loops_remaining = Some(remaining - 1);
+                    self.state.position = 0;
+                }
+                Some(_) => {
+                    self.finished = true;
+                    return None;
+                }
+                None => {
+                    self.state.position = 0;
+                }
+            }
+        }
+    }
 }
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct AudioState {
     pub volume: f32,
-    pub music_owner: Option<String>,
-    pub pending_samples: Vec<i16>,
+    channels: Vec<SavedChannel>,
+    next_channel_id: usize,
+    sample_frame_remainder: u32,
     pub tone_phase: f64,
     pub tone_active: bool,
 }
@@ -55,11 +125,12 @@ impl AudioEngine {
             Self {
                 _mixer_device: mixer_device,
                 mixer,
-                player: None,
+                music_player: None,
+                sound_players: Vec::new(),
                 volume: volume as f32 / 100.0,
                 colorspace,
-                music_owner: None,
-                pending_samples: Vec::new(),
+                next_channel_id: 1,
+                sample_frame_remainder: 0,
                 tone_phase: 0.0,
                 tone_active: false,
             }
@@ -70,8 +141,9 @@ impl AudioEngine {
             Self {
                 volume: volume as f32 / 100.0,
                 colorspace,
-                music_owner: None,
-                pending_samples: Vec::new(),
+                next_channel_id: 1,
+                sample_frame_remainder: 0,
+                channels: Vec::new(),
                 tone_phase: 0.0,
                 tone_active: false,
             }
@@ -82,47 +154,57 @@ impl AudioEngine {
     /// Returns interleaved stereo i16 samples.
     /// This should be called once per frame in retro_run().
     pub fn get_pending_samples(&mut self) -> Vec<i16> {
-        // Calculate how many samples we need per frame at 30fps
-        let sample_rate = match self.colorspace {
-            Colorspace::YUV => 11025.0,
-            Colorspace::ARGB => 22050.0,
-        };
-        // Number of stereo frames to emit per 30fps video frame.
-        let frames_per_video_frame = (sample_rate / 30.0) as usize;
-        // The buffer is interleaved stereo, so each frame is two i16 values (L + R).
+        let sample_rate = self.output_sample_rate();
+        self.sample_frame_remainder += sample_rate;
+        let frames_per_video_frame = (self.sample_frame_remainder / 30) as usize;
+        self.sample_frame_remainder %= 30;
         let values_per_video_frame = frames_per_video_frame * 2;
 
-        // If we have pending samples from play_raw/play_mp3, use those
-        if !self.pending_samples.is_empty() {
-            // Take one video frame's worth of interleaved samples from the buffer
-            let take_count = values_per_video_frame.min(self.pending_samples.len());
-            let mut result: Vec<i16> = self.pending_samples.drain(..take_count).collect();
+        #[cfg(feature = "standalone")]
+        let mut result = vec![0i16; values_per_video_frame];
 
-            // If we need more samples to fill the frame, pad with silence
-            if result.len() < values_per_video_frame {
-                result.resize(values_per_video_frame, 0);
-            }
-            result
-        } else if self.tone_active {
-            // Generate test tone for debugging
-            let mut samples = Vec::with_capacity(values_per_video_frame);
-
-            for _ in 0..frames_per_video_frame {
-                let sample =
-                    (self.tone_phase * 2.0 * std::f64::consts::PI * 440.0 / sample_rate).sin();
-                let sample_i16 = (sample * 16000.0 * self.volume as f64) as i16;
-                samples.push(sample_i16); // Left
-                samples.push(sample_i16); // Right
-                self.tone_phase += 1.0;
-                if self.tone_phase >= sample_rate {
-                    self.tone_phase -= sample_rate;
+        #[cfg(not(feature = "standalone"))]
+        let mut result = {
+            let mut mixed = vec![(0i32, 0i32); frames_per_video_frame];
+            for channel in &mut self.channels {
+                for frame in &mut mixed {
+                    let Some((left, right)) = channel.next_frame() else {
+                        break;
+                    };
+                    frame.0 += left as i32;
+                    frame.1 += right as i32;
                 }
             }
-            samples
-        } else {
-            // Return silence
-            vec![0i16; values_per_video_frame]
+            self.channels.retain(|channel| !channel.finished);
+
+            let mut output = Vec::with_capacity(values_per_video_frame);
+            for (left, right) in mixed {
+                output.push(
+                    (left as f32 * self.volume).clamp(i16::MIN as f32, i16::MAX as f32) as i16,
+                );
+                output.push(
+                    (right as f32 * self.volume).clamp(i16::MIN as f32, i16::MAX as f32) as i16,
+                );
+            }
+            output
+        };
+
+        if self.tone_active {
+            for frame in result.chunks_exact_mut(2) {
+                let sample = (self.tone_phase * 2.0 * std::f64::consts::PI * 440.0
+                    / sample_rate as f64)
+                    .sin();
+                let sample_i16 = (sample * 16000.0 * self.volume as f64) as i16;
+                frame[0] = frame[0].saturating_add(sample_i16);
+                frame[1] = frame[1].saturating_add(sample_i16);
+                self.tone_phase += 1.0;
+                if self.tone_phase >= sample_rate as f64 {
+                    self.tone_phase -= sample_rate as f64;
+                }
+            }
         }
+
+        result
     }
 
     /// Start a test tone (for debugging).
@@ -136,25 +218,37 @@ impl AudioEngine {
         self.tone_active = false;
     }
 
-    /// Play a sound. Returns true if playback started.
+    fn output_sample_rate(&self) -> u32 {
+        match self.colorspace {
+            Colorspace::YUV => 11025,
+            Colorspace::ARGB => 22050,
+        }
+    }
+
+    fn allocate_channel_id(&mut self) -> usize {
+        let id = self.next_channel_id;
+        self.next_channel_id = self.next_channel_id.wrapping_add(1).max(1);
+        id
+    }
+
+    /// Play a sound and return its channel identifier.
     pub fn play_sound(
         &mut self,
         reader: &mut Native32Reader,
         sound_value: u16,
         movie_name: &str,
-    ) -> bool {
-        let repeat = ((sound_value >> 8) & 0xFF) as i32;
+    ) -> Option<usize> {
+        let repeat = ((sound_value >> 8) & 0xFF) as u8;
         let index = (sound_value & 0xFF) as u32;
-
         if index == 0 {
-            return false;
+            return None;
         }
 
         let sound = match reader.get_sound(index) {
-            Some(s) => s,
+            Some(sound) => sound,
             None => {
                 log::warn!("Failed to load sound {}", index);
-                return false;
+                return None;
             }
         };
 
@@ -165,22 +259,93 @@ impl AudioEngine {
     }
 
     #[cfg(not(feature = "standalone"))]
-    fn play_mp3(&mut self, _data: &[u8], _repeat: i32, _movie_name: &str) -> bool {
-        // In libretro mode, we need to decode MP3 and store samples in buffer
-        // For now, we'll use a simple approach: decode and store
-        // TODO: Implement proper MP3 decoding for libretro mode
-        log::debug!("MP3 playback requested (libretro mode - simplified implementation)");
+    fn play_mp3(&mut self, data: &[u8], repeat: u8, movie_name: &str) -> Option<usize> {
+        let samples = match decode_mp3(data, self.output_sample_rate()) {
+            Ok(samples) => samples,
+            Err(error) => {
+                log::warn!("Failed to decode MP3: {error}");
+                return None;
+            }
+        };
+        self.add_channel(
+            samples,
+            SavedAudioSource::Mp3(data.to_vec()),
+            repeat,
+            movie_name,
+            true,
+        )
+    }
 
-        // For MP3, we'll need a decoder. For now, return false to indicate not supported
-        // A proper implementation would use a Rust MP3 decoder library
-        false
+    #[cfg(not(feature = "standalone"))]
+    fn play_raw(&mut self, data: &[u8], repeat: u8, movie_name: &str) -> Option<usize> {
+        let samples = raw_pcm_to_stereo(data);
+        self.add_channel(
+            samples,
+            SavedAudioSource::Raw(data.to_vec()),
+            repeat,
+            movie_name,
+            false,
+        )
+    }
+
+    #[cfg(not(feature = "standalone"))]
+    fn add_channel(
+        &mut self,
+        samples: Vec<i16>,
+        source: SavedAudioSource,
+        repeat: u8,
+        owner: &str,
+        is_music: bool,
+    ) -> Option<usize> {
+        if samples.is_empty() {
+            return None;
+        }
+        self.channels.retain(|channel| !channel.finished);
+        if is_music {
+            self.channels.retain(|channel| !channel.state.is_music);
+        } else if self
+            .channels
+            .iter()
+            .filter(|channel| !channel.state.is_music)
+            .count()
+            >= MAX_SOUND_EFFECTS
+        {
+            return None;
+        }
+
+        let id = self.allocate_channel_id();
+        self.channels.push(PlaybackChannel {
+            state: SavedChannel {
+                id,
+                owner: owner.to_string(),
+                source,
+                position: 0,
+                loops_remaining: (repeat != 0xFF).then_some(repeat as u32),
+                is_music,
+            },
+            samples,
+            finished: false,
+        });
+        self.tone_active = false;
+        Some(id)
     }
 
     pub(crate) fn save_state(&self) -> AudioState {
+        #[cfg(feature = "standalone")]
+        let channels = Vec::new();
+        #[cfg(not(feature = "standalone"))]
+        let channels = self
+            .channels
+            .iter()
+            .filter(|channel| !channel.finished)
+            .map(|channel| channel.state.clone())
+            .collect();
+
         AudioState {
             volume: self.volume,
-            music_owner: self.music_owner.clone(),
-            pending_samples: self.pending_samples.clone(),
+            channels,
+            next_channel_id: self.next_channel_id,
+            sample_frame_remainder: self.sample_frame_remainder,
             tone_phase: self.tone_phase,
             tone_active: self.tone_active,
         }
@@ -189,142 +354,111 @@ impl AudioEngine {
     pub(crate) fn restore_state(&mut self, state: AudioState) {
         self.stop_all();
         self.volume = state.volume.clamp(0.0, 1.0);
-        self.music_owner = state.music_owner;
-        self.pending_samples = state.pending_samples;
+        self.next_channel_id = state.next_channel_id.max(1);
+        self.sample_frame_remainder = state.sample_frame_remainder % 30;
         self.tone_phase = state.tone_phase;
         self.tone_active = state.tone_active;
-    }
 
-    #[cfg(not(feature = "standalone"))]
-    fn play_raw(&mut self, data: &[u8], repeat: i32, movie_name: &str) -> bool {
-        log::debug!("Raw audio playback requested (libretro mode)");
-
-        // Decode raw 16-bit PCM data (little-endian based on the standalone implementation)
-        let mono_samples: Vec<i16> = data
-            .chunks_exact(2)
-            .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]))
-            .collect();
-
-        if mono_samples.is_empty() {
-            return false;
-        }
-
-        // Apply volume and convert mono to stereo (libretro expects interleaved stereo)
-        let volume_scale = self.volume;
-        let mut stereo_samples = Vec::with_capacity(mono_samples.len() * 2);
-        for &sample in &mono_samples {
-            let scaled = (sample as f32 * volume_scale) as i16;
-            stereo_samples.push(scaled); // Left
-            stereo_samples.push(scaled); // Right (same as left for mono source)
-        }
-
-        // Store samples in pending buffer based on repeat count
-        let repeat_count = if repeat == 0xFF {
-            // Infinite loop - for now, just play once (could be improved with a loop flag)
-            1
-        } else if repeat > 1 {
-            repeat as usize
-        } else {
-            1
-        };
-
-        // Clear previous samples and add new ones
-        self.pending_samples.clear();
-        for _ in 0..repeat_count {
-            self.pending_samples.extend_from_slice(&stereo_samples);
-        }
-
-        self.music_owner = Some(movie_name.to_string());
-        self.tone_active = false; // Disable test tone when real audio is playing
-        true
-    }
-
-    #[cfg(feature = "standalone")]
-    fn play_mp3(&mut self, data: &[u8], repeat: i32, movie_name: &str) -> bool {
-        if let Some(ref mixer) = self.mixer {
-            // Stop current music
-            if let Some(ref player) = self.player {
-                player.stop();
-            }
-
-            let player = rodio::Player::connect_new(mixer);
-            player.set_volume(self.volume);
-
-            // Create a cursor from the data
-            let cursor = std::io::Cursor::new(data.to_vec());
-            match rodio::Decoder::new_mp3(cursor) {
-                Ok(decoder) => {
-                    let buffered = decoder.buffered();
-                    if repeat == 0xFF {
-                        // Infinite loop
-                        player.append(buffered.repeat_infinite());
-                    } else if repeat > 1 {
-                        // Finite repeat: append the buffered source N times
-                        for _ in 0..repeat {
-                            player.append(buffered.clone());
-                        }
-                    } else {
-                        // Play once (repeat == 0 or 1)
-                        player.append(buffered);
+        #[cfg(not(feature = "standalone"))]
+        for saved in state.channels {
+            let samples = match &saved.source {
+                SavedAudioSource::Mp3(data) => match decode_mp3(data, self.output_sample_rate()) {
+                    Ok(samples) => samples,
+                    Err(error) => {
+                        log::warn!("Failed to restore MP3 channel: {error}");
+                        continue;
                     }
-                    self.player = Some(player);
-                    self.music_owner = Some(movie_name.to_string());
-                    true
-                }
-                Err(e) => {
-                    log::warn!("Failed to decode MP3: {}", e);
-                    false
-                }
-            }
-        } else {
-            false
+                },
+                SavedAudioSource::Raw(data) => raw_pcm_to_stereo(data),
+                SavedAudioSource::DecodedPcm(samples) => samples.clone(),
+            };
+            let mut saved = saved;
+            saved.position = saved.position.min(samples.len() / 2);
+            self.channels.push(PlaybackChannel {
+                state: saved,
+                samples,
+                finished: false,
+            });
         }
     }
 
     #[cfg(feature = "standalone")]
-    fn play_raw(&mut self, data: &[u8], repeat: i32, movie_name: &str) -> bool {
-        if let Some(ref mixer) = self.mixer {
-            // Determine sample rate based on colorspace
-            let sample_rate = match self.colorspace {
-                Colorspace::YUV => 11025u32,
-                Colorspace::ARGB => 22050u32,
-            };
-
-            // Convert raw 16-bit mono PCM to f32 samples
-            let samples: Vec<f32> = data
-                .chunks_exact(2)
-                .map(|chunk| {
-                    let sample = i16::from_le_bytes([chunk[0], chunk[1]]);
-                    sample as f32 / 32768.0
-                })
-                .collect();
-
-            let source = rodio::buffer::SamplesBuffer::new(
-                NonZero::<u16>::new(1).unwrap(),
-                NonZero::<u32>::new(sample_rate).unwrap(),
-                samples,
-            );
-
-            let player = rodio::Player::connect_new(mixer);
-            player.set_volume(self.volume);
-
-            if repeat == 0xFF {
-                player.append(source.repeat_infinite());
-            } else if repeat > 1 {
-                let buffered = source.buffered();
-                for _ in 0..repeat {
-                    player.append(buffered.clone());
-                }
-            } else {
-                player.append(source);
-            }
-
-            self.player = Some(player);
-            self.music_owner = Some(movie_name.to_string());
-            true
-        } else {
-            false
+    fn play_mp3(&mut self, data: &[u8], repeat: u8, movie_name: &str) -> Option<usize> {
+        let mixer = self.mixer.clone()?;
+        if let Some(channel) = self.music_player.take() {
+            channel.player.stop();
         }
+
+        let player = rodio::Player::connect_new(&mixer);
+        player.set_volume(self.volume);
+        let cursor = std::io::Cursor::new(data.to_vec());
+        let decoder = match rodio::Decoder::new_mp3(cursor) {
+            Ok(decoder) => decoder,
+            Err(error) => {
+                log::warn!("Failed to decode MP3: {error}");
+                return None;
+            }
+        };
+        let buffered = decoder.buffered();
+        if repeat == 0xFF {
+            player.append(buffered.repeat_infinite());
+        } else {
+            player.append(buffered.clone());
+            for _ in 0..repeat {
+                player.append(buffered.clone());
+            }
+        }
+
+        let id = self.allocate_channel_id();
+        self.music_player = Some(StandaloneChannel {
+            id,
+            owner: movie_name.to_string(),
+            player,
+        });
+        self.tone_active = false;
+        Some(id)
+    }
+
+    #[cfg(feature = "standalone")]
+    fn play_raw(&mut self, data: &[u8], repeat: u8, movie_name: &str) -> Option<usize> {
+        let mixer = self.mixer.clone()?;
+        self.sound_players.retain(|channel| !channel.player.empty());
+        if self.sound_players.len() >= MAX_SOUND_EFFECTS {
+            return None;
+        }
+
+        let samples: Vec<f32> = data
+            .chunks_exact(2)
+            .map(|chunk| i16::from_le_bytes([chunk[0], chunk[1]]) as f32 / 32768.0)
+            .collect();
+        if samples.is_empty() {
+            return None;
+        }
+        let source = rodio::buffer::SamplesBuffer::new(
+            NonZero::<u16>::new(1).unwrap(),
+            NonZero::<u32>::new(self.output_sample_rate()).unwrap(),
+            samples,
+        );
+        let player = rodio::Player::connect_new(&mixer);
+        player.set_volume(self.volume);
+        let buffered = source.buffered();
+        if repeat == 0xFF {
+            player.append(buffered.repeat_infinite());
+        } else {
+            player.append(buffered.clone());
+            for _ in 0..repeat {
+                player.append(buffered.clone());
+            }
+        }
+
+        let id = self.allocate_channel_id();
+        self.sound_players.push(StandaloneChannel {
+            id,
+            owner: movie_name.to_string(),
+            player,
+        });
+        self.tone_active = false;
+        Some(id)
     }
 
     /// Play a fully-decoded interleaved PCM stream (used for cutscene audio).
@@ -334,89 +468,124 @@ impl AudioEngine {
         if samples.is_empty() || channels == 0 || sample_rate == 0 {
             return;
         }
-        if let Some(ref mixer) = self.mixer {
-            if let Some(ref player) = self.player {
-                player.stop();
-            }
-            let source = rodio::buffer::SamplesBuffer::new(
-                NonZero::<u16>::new(channels).unwrap(),
-                NonZero::<u32>::new(sample_rate).unwrap(),
-                samples,
-            );
-            let player = rodio::Player::connect_new(mixer);
-            player.set_volume(self.volume);
-            player.append(source);
-            self.player = Some(player);
-            self.music_owner = Some("__cutscene__".to_string());
+        let Some(mixer) = self.mixer.clone() else {
+            return;
+        };
+        if let Some(channel) = self.music_player.take() {
+            channel.player.stop();
         }
+        let source = rodio::buffer::SamplesBuffer::new(
+            NonZero::<u16>::new(channels).unwrap(),
+            NonZero::<u32>::new(sample_rate).unwrap(),
+            samples,
+        );
+        let player = rodio::Player::connect_new(&mixer);
+        player.set_volume(self.volume);
+        player.append(source);
+        let id = self.allocate_channel_id();
+        self.music_player = Some(StandaloneChannel {
+            id,
+            owner: "__cutscene__".to_string(),
+            player,
+        });
     }
 
-    /// Libretro variant: resample to the engine's output rate and stage the
-    /// samples for `get_pending_samples` to drain.
     #[cfg(not(feature = "standalone"))]
     pub fn play_pcm_stream(&mut self, samples: Vec<f32>, channels: u16, sample_rate: u32) {
-        if samples.is_empty() || channels == 0 || sample_rate == 0 {
-            return;
-        }
-        let out_rate = match self.colorspace {
-            Colorspace::YUV => 11025u32,
-            Colorspace::ARGB => 22050u32,
-        };
-        let ch = channels as usize;
-        let in_frames = samples.len() / ch;
-        let out_frames = (in_frames as u64 * out_rate as u64 / sample_rate as u64) as usize;
-        let mut out = Vec::with_capacity(out_frames * 2);
-        for i in 0..out_frames {
-            let src =
-                ((i as u64 * sample_rate as u64 / out_rate as u64) as usize).min(in_frames - 1);
-            let base = src * ch;
-            let l = samples[base];
-            let r = if ch >= 2 { samples[base + 1] } else { l };
-            out.push((l * 32767.0 * self.volume).clamp(-32768.0, 32767.0) as i16);
-            out.push((r * 32767.0 * self.volume).clamp(-32768.0, 32767.0) as i16);
-        }
-        self.pending_samples = out;
-        self.tone_active = false;
+        let output = resample_to_stereo(
+            &samples,
+            channels as usize,
+            sample_rate,
+            self.output_sample_rate(),
+        );
+        let _ = self.add_channel(
+            output.clone(),
+            SavedAudioSource::DecodedPcm(output),
+            0,
+            "__cutscene__",
+            true,
+        );
     }
 
     /// Stop all currently playing sounds.
     pub fn stop_all(&mut self) {
         #[cfg(feature = "standalone")]
-        if let Some(ref player) = self.player {
-            player.stop();
-        }
-        #[cfg(feature = "standalone")]
         {
-            self.player = None;
+            if let Some(channel) = self.music_player.take() {
+                channel.player.stop();
+            }
+            for channel in self.sound_players.drain(..) {
+                channel.player.stop();
+            }
         }
-        self.music_owner = None;
+        #[cfg(not(feature = "standalone"))]
+        self.channels.clear();
+
         self.tone_active = false;
     }
 
-    /// Stop sound only if the given movie is the current owner.
+    /// Stop sounds owned by the given movie.
     pub fn stop_for_movie(&mut self, movie_name: &str) {
-        if self.music_owner.as_deref() == Some(movie_name) {
-            #[cfg(feature = "standalone")]
-            if let Some(ref player) = self.player {
-                player.stop();
-            }
-            #[cfg(feature = "standalone")]
-            {
-                self.player = None;
-            }
-            self.music_owner = None;
-        }
-    }
-
-    /// Check if music is still playing.
-    pub fn is_playing(&self) -> bool {
         #[cfg(feature = "standalone")]
         {
-            self.player.as_ref().is_some_and(|p| !p.empty())
+            if self
+                .music_player
+                .as_ref()
+                .is_some_and(|channel| channel.owner == movie_name)
+            {
+                if let Some(channel) = self.music_player.take() {
+                    channel.player.stop();
+                }
+            }
+            let mut retained = Vec::with_capacity(self.sound_players.len());
+            for channel in self.sound_players.drain(..) {
+                if channel.owner == movie_name {
+                    channel.player.stop();
+                } else {
+                    retained.push(channel);
+                }
+            }
+            self.sound_players = retained;
+        }
+        #[cfg(not(feature = "standalone"))]
+        self.channels
+            .retain(|channel| channel.state.owner != movie_name);
+    }
+
+    pub fn is_channel_playing(&self, channel_id: usize) -> bool {
+        #[cfg(feature = "standalone")]
+        {
+            self.music_player
+                .as_ref()
+                .is_some_and(|channel| channel.id == channel_id && !channel.player.empty())
+                || self
+                    .sound_players
+                    .iter()
+                    .any(|channel| channel.id == channel_id && !channel.player.empty())
         }
         #[cfg(not(feature = "standalone"))]
         {
-            self.tone_active
+            self.channels
+                .iter()
+                .any(|channel| channel.state.id == channel_id && !channel.finished)
+        }
+    }
+
+    pub fn is_playing(&self) -> bool {
+        #[cfg(feature = "standalone")]
+        {
+            self.music_player
+                .as_ref()
+                .is_some_and(|channel| !channel.player.empty())
+                || self
+                    .sound_players
+                    .iter()
+                    .any(|channel| !channel.player.empty())
+                || self.tone_active
+        }
+        #[cfg(not(feature = "standalone"))]
+        {
+            self.channels.iter().any(|channel| !channel.finished) || self.tone_active
         }
     }
 
@@ -424,8 +593,260 @@ impl AudioEngine {
     pub fn set_volume(&mut self, volume: u32) {
         self.volume = volume as f32 / 100.0;
         #[cfg(feature = "standalone")]
-        if let Some(ref player) = self.player {
-            player.set_volume(self.volume);
+        {
+            if let Some(channel) = &self.music_player {
+                channel.player.set_volume(self.volume);
+            }
+            for channel in &self.sound_players {
+                channel.player.set_volume(self.volume);
+            }
         }
+    }
+}
+
+#[cfg(not(feature = "standalone"))]
+fn raw_pcm_to_stereo(data: &[u8]) -> Vec<i16> {
+    let mut output = Vec::with_capacity(data.len());
+    for chunk in data.chunks_exact(2) {
+        let sample = i16::from_le_bytes([chunk[0], chunk[1]]);
+        output.push(sample);
+        output.push(sample);
+    }
+    output
+}
+
+#[cfg(not(feature = "standalone"))]
+fn resample_to_stereo(
+    samples: &[f32],
+    channels: usize,
+    input_rate: u32,
+    output_rate: u32,
+) -> Vec<i16> {
+    if samples.is_empty() || channels == 0 || input_rate == 0 || output_rate == 0 {
+        return Vec::new();
+    }
+    let input_frames = samples.len() / channels;
+    if input_frames == 0 {
+        return Vec::new();
+    }
+    let output_frames =
+        (input_frames as u64 * output_rate as u64).div_ceil(input_rate as u64) as usize;
+    let mut output = Vec::with_capacity(output_frames * 2);
+
+    for output_frame in 0..output_frames {
+        let position = output_frame as u64 * input_rate as u64;
+        let source_frame = (position / output_rate as u64) as usize;
+        let next_frame = (source_frame + 1).min(input_frames - 1);
+        let fraction = (position % output_rate as u64) as f32 / output_rate as f32;
+
+        for channel in 0..2 {
+            let source_channel = channel.min(channels - 1);
+            let first = samples[source_frame.min(input_frames - 1) * channels + source_channel];
+            let second = samples[next_frame * channels + source_channel];
+            let sample = first + (second - first) * fraction;
+            output.push((sample * 32767.0).clamp(i16::MIN as f32, i16::MAX as f32) as i16);
+        }
+    }
+    output
+}
+
+#[cfg(not(feature = "standalone"))]
+fn decode_mp3(data: &[u8], output_rate: u32) -> anyhow::Result<Vec<i16>> {
+    let source = Box::new(std::io::Cursor::new(data.to_vec()));
+    let stream = MediaSourceStream::new(source, Default::default());
+    let mut hint = Hint::new();
+    hint.with_extension("mp3");
+    let probed = symphonia::default::get_probe()
+        .format(
+            &hint,
+            stream,
+            &FormatOptions::default(),
+            &MetadataOptions::default(),
+        )
+        .map_err(|error| anyhow::anyhow!("failed to probe MP3 stream: {error}"))?;
+    let mut format = probed.format;
+    let track = format
+        .default_track()
+        .ok_or_else(|| anyhow::anyhow!("MP3 stream has no audio track"))?;
+    let track_id = track.id;
+    let mut decoder = symphonia::default::get_codecs()
+        .make(&track.codec_params, &DecoderOptions::default())
+        .map_err(|error| anyhow::anyhow!("failed to create MP3 decoder: {error}"))?;
+
+    let mut decoded = Vec::new();
+    let mut sample_rate = 0;
+    let mut channel_count = 0;
+    loop {
+        let packet = match format.next_packet() {
+            Ok(packet) => packet,
+            Err(SymphoniaError::IoError(error))
+                if error.kind() == std::io::ErrorKind::UnexpectedEof =>
+            {
+                break;
+            }
+            Err(SymphoniaError::ResetRequired) => {
+                return Err(anyhow::anyhow!("MP3 stream changed tracks while decoding"));
+            }
+            Err(error) => return Err(anyhow::anyhow!("failed to read MP3 packet: {error}")),
+        };
+        if packet.track_id() != track_id {
+            continue;
+        }
+        let audio = match decoder.decode(&packet) {
+            Ok(audio) => audio,
+            Err(SymphoniaError::DecodeError(error)) => {
+                log::debug!("Skipping malformed MP3 packet: {error}");
+                continue;
+            }
+            Err(SymphoniaError::IoError(error))
+                if error.kind() == std::io::ErrorKind::UnexpectedEof =>
+            {
+                break;
+            }
+            Err(error) => return Err(anyhow::anyhow!("failed to decode MP3 packet: {error}")),
+        };
+        let spec = *audio.spec();
+        if sample_rate == 0 {
+            sample_rate = spec.rate;
+            channel_count = spec.channels.count();
+        } else if sample_rate != spec.rate || channel_count != spec.channels.count() {
+            return Err(anyhow::anyhow!(
+                "MP3 stream changed audio format while decoding"
+            ));
+        }
+        let mut sample_buffer = SampleBuffer::<f32>::new(audio.capacity() as u64, spec);
+        sample_buffer.copy_interleaved_ref(audio);
+        decoded.extend_from_slice(sample_buffer.samples());
+    }
+
+    if sample_rate == 0 || channel_count == 0 || decoded.is_empty() {
+        return Err(anyhow::anyhow!("MP3 stream decoded to no samples"));
+    }
+    Ok(resample_to_stereo(
+        &decoded,
+        channel_count,
+        sample_rate,
+        output_rate,
+    ))
+}
+#[cfg(all(test, not(feature = "standalone")))]
+mod tests {
+    use super::*;
+
+    fn engine() -> AudioEngine {
+        AudioEngine::new(Colorspace::YUV, 100)
+    }
+
+    #[test]
+    fn emits_exact_fractional_sample_rate_over_two_frames() {
+        let mut audio = engine();
+        let first = audio.get_pending_samples();
+        let second = audio.get_pending_samples();
+
+        assert_eq!(first.len() / 2, 367);
+        assert_eq!(second.len() / 2, 368);
+        assert_eq!((first.len() + second.len()) / 2, 735);
+    }
+
+    #[test]
+    fn playback_channel_honors_finite_and_infinite_loops() {
+        let state = SavedChannel {
+            id: 1,
+            owner: "finite".to_string(),
+            source: SavedAudioSource::DecodedPcm(vec![100, 100]),
+            position: 0,
+            loops_remaining: Some(2),
+            is_music: false,
+        };
+        let mut finite = PlaybackChannel {
+            state,
+            samples: vec![100, 100],
+            finished: false,
+        };
+        assert_eq!(finite.next_frame(), Some((100, 100)));
+        assert_eq!(finite.next_frame(), Some((100, 100)));
+        assert_eq!(finite.next_frame(), Some((100, 100)));
+        assert_eq!(finite.next_frame(), None);
+
+        let mut infinite = PlaybackChannel {
+            state: SavedChannel {
+                id: 2,
+                owner: "infinite".to_string(),
+                source: SavedAudioSource::DecodedPcm(vec![200, 200]),
+                position: 0,
+                loops_remaining: None,
+                is_music: true,
+            },
+            samples: vec![200, 200],
+            finished: false,
+        };
+        for _ in 0..100 {
+            assert_eq!(infinite.next_frame(), Some((200, 200)));
+        }
+    }
+
+    #[test]
+    fn mixes_background_music_and_sound_effects_without_interrupting_music() {
+        let mut audio = engine();
+        let music = vec![1000, 1000];
+        let effect = vec![2000, 2000];
+        let music_id = audio
+            .add_channel(
+                music.clone(),
+                SavedAudioSource::DecodedPcm(music),
+                0xFF,
+                "music",
+                true,
+            )
+            .unwrap();
+        let effect_id = audio
+            .add_channel(
+                effect.clone(),
+                SavedAudioSource::DecodedPcm(effect),
+                0,
+                "effect",
+                false,
+            )
+            .unwrap();
+
+        let output = audio.get_pending_samples();
+        assert_eq!(&output[..4], &[3000, 3000, 1000, 1000]);
+        assert!(audio.is_channel_playing(music_id));
+        assert!(!audio.is_channel_playing(effect_id));
+    }
+
+    #[test]
+    fn save_state_restores_channel_position_and_looping() {
+        let mut audio = engine();
+        let music = vec![1000, 1000, 2000, 2000];
+        let channel_id = audio
+            .add_channel(
+                music.clone(),
+                SavedAudioSource::DecodedPcm(music),
+                0xFF,
+                "music",
+                true,
+            )
+            .unwrap();
+        let _ = audio.get_pending_samples();
+        let state = audio.save_state();
+
+        let mut restored = engine();
+        restored.restore_state(state);
+        assert!(restored.is_channel_playing(channel_id));
+        assert!(restored
+            .get_pending_samples()
+            .iter()
+            .any(|sample| *sample != 0));
+    }
+
+    #[test]
+    fn resamples_mono_audio_to_stereo_without_changing_duration() {
+        let input = vec![0.0, 0.25, 0.5, 1.0];
+        let output = resample_to_stereo(&input, 1, 22050, 11025);
+
+        assert_eq!(output.len(), 4);
+        assert_eq!(output[0], output[1]);
+        assert_eq!(output[2], output[3]);
     }
 }

--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -293,9 +293,12 @@ impl Emulator {
 
                 if let Some((sound, action)) = frame_data {
                     // Play sound if present and track it on the movie
-                    if sound != 0 && self.audio.play_sound(&mut self.reader, sound, name) {
-                        if let Some(movie) = self.sprites.get_mut(name) {
-                            movie.sound_channel = Some(0);
+                    if sound != 0 {
+                        if let Some(channel) = self.audio.play_sound(&mut self.reader, sound, name)
+                        {
+                            if let Some(movie) = self.sprites.get_mut(name) {
+                                movie.sound_channel = Some(channel);
+                            }
                         }
                     }
 
@@ -316,13 +319,13 @@ impl Emulator {
             }
         }
 
-        // Handle ended sounds
-        if !self.audio.is_playing() {
-            if let Some(owner) = self.audio.music_owner.clone() {
-                if let Some(movie) = self.sprites.get_mut(&owner) {
-                    movie.sound_channel = None;
-                }
-                self.audio.music_owner = None;
+        // Release movies whose sound channel reached the end.
+        for (_, movie) in self.sprites.iter_mut() {
+            if movie
+                .sound_channel
+                .is_some_and(|channel| !self.audio.is_channel_playing(channel))
+            {
+                movie.sound_channel = None;
             }
         }
 

--- a/crates/native32emu-core/src/file_loader.rs
+++ b/crates/native32emu-core/src/file_loader.rs
@@ -209,7 +209,7 @@ impl Native32Reader {
         // 8 bytes: fps_color_size(2) + action_stack_var(2) + button_movieclip(2) + buffer_sound(2)
         // 16 bytes: load_addr(4) + binary_size(4) + mp3_offset(4) + mp3_length(4)
         // Total: 24 = 0x18 bytes
-        self.mp3_offset = read_u32_le(&self.data, self.base + 0x18);
+        self.mp3_offset = read_u32_le(&self.data, self.base + 0x10);
 
         // Decrypt the 32-byte encrypted header at base + 0x18
         let enc_start = self.base + 0x18;
@@ -455,37 +455,36 @@ impl Native32Reader {
             return Some(cached.clone());
         }
 
-        let table_idx = self.sound_table + (idx - 1) as usize * 4;
-        if table_idx + 4 > self.data.len() {
-            return None;
-        }
+        let table_offset = usize::try_from(idx.checked_sub(1)?).ok()?.checked_mul(4)?;
+        let table_idx = self.sound_table.checked_add(table_offset)?;
+        self.data.get(table_idx..table_idx.checked_add(4)?)?;
         let ptr = read_u32_le(&self.data, table_idx);
         let flags = ptr & 0xF0000000;
         let addr = (ptr & 0x0FFFFFFF) as usize;
 
         let result = if flags == 0xF0000000 {
             // MP3 audio
-            let begin = self.base + self.mp3_offset as usize + addr;
-            if begin + 6 > self.data.len() {
-                return None;
-            }
+            let begin = self
+                .base
+                .checked_add(self.mp3_offset as usize)?
+                .checked_add(addr)?;
+            self.data.get(begin..begin.checked_add(6)?)?;
             let size = read_u32_le(&self.data, begin) as usize;
-            let data_start = begin + 6;
-            let data_end = std::cmp::min(data_start + size, self.data.len());
+            let data_start = begin.checked_add(6)?;
+            let data_end = data_start.checked_add(size)?;
+            let data = self.data.get(data_start..data_end)?;
             SoundData {
                 format: AudioFormat::MP3,
-                data: self.data[data_start..data_end].to_vec(),
+                data: data.to_vec(),
             }
         } else if flags == 0x00000000 {
             // Raw PCM
-            let begin = self.base + addr;
-            if begin + 4 > self.data.len() {
-                return None;
-            }
+            let begin = self.base.checked_add(addr)?;
+            self.data.get(begin..begin.checked_add(4)?)?;
             let size = read_u32_le(&self.data, begin) as usize;
-            let data_start = begin + 4;
-            let data_end = std::cmp::min(data_start + size, self.data.len());
-            let raw_data = &self.data[data_start..data_end];
+            let data_start = begin.checked_add(4)?;
+            let data_end = data_start.checked_add(size)?;
+            let raw_data = self.data.get(data_start..data_end)?;
 
             if self.colorspace == Colorspace::YUV {
                 // Big-endian to little-endian conversion

--- a/crates/native32emu-core/src/save_state.rs
+++ b/crates/native32emu-core/src/save_state.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 const MAGIC: &[u8; 8] = b"N32STATE";
-const VERSION: u32 = 1;
+const VERSION: u32 = 2;
 const HEADER_SIZE: usize = 20;
 
 /// libretro requires this value to remain constant for a loaded core.

--- a/crates/native32emu-core/tests/smoke.rs
+++ b/crates/native32emu-core/tests/smoke.rs
@@ -454,6 +454,53 @@ fn magical_adventure_minigame_confirm_starts_timer() {
         emu.vm.vars.get("mgstate")
     );
 }
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn magical_adventure_mp3_music_decodes_mixes_and_loops() {
+    let dir = game_dir().expect("no game directory found");
+    let game = find_asset(&dir, "MagicalA.smf").expect("MagicalA.smf not found");
+    let mut emu = Emulator::from_path(game, 100).expect("load Magical Adventure");
+
+    let channel = emu
+        .audio
+        .play_sound(&mut emu.reader, 0xFF01, "regression_bgm")
+        .expect("decode looping MP3 background music");
+    let effect_channel = emu
+        .audio
+        .play_sound(&mut emu.reader, 0x0007, "regression_effect")
+        .expect("play RAW sound effect alongside MP3 music");
+    assert!(emu.audio.is_channel_playing(channel));
+    assert!(emu.audio.is_channel_playing(effect_channel));
+
+    let mut non_silent_frames = 0;
+    for _ in 0..900 {
+        let samples = emu.get_pending_audio_samples();
+        if samples.iter().any(|sample| *sample != 0) {
+            non_silent_frames += 1;
+        }
+    }
+
+    assert!(
+        non_silent_frames > 800,
+        "decoded MP3 unexpectedly contained prolonged silence"
+    );
+    assert!(
+        emu.audio.is_channel_playing(channel),
+        "0xFF MP3 background music stopped instead of looping"
+    );
+    assert!(
+        !emu.audio.is_channel_playing(effect_channel),
+        "one-shot RAW sound effect did not finish"
+    );
+
+    let mut state = vec![0; emu.serialize_size()];
+    emu.serialize(&mut state).expect("save active MP3 state");
+    emu.deserialize(&state).expect("restore active MP3 state");
+    assert!(
+        emu.audio.is_channel_playing(channel),
+        "active MP3 channel was not restored from save state"
+    );
+}
 /// Test ZIP file loading: a ZIP archive containing FHUI.smf should be extracted
 /// and the main menu loaded automatically.
 #[test]


### PR DESCRIPTION
## Summary

Closes #50.

Restores missing looping MP3 background music in both the libretro core and the standalone frontend, while preserving simultaneous RAW PCM sound effects and correct movie playback synchronization.

Related issue comments:

- https://github.com/jiangxincode/Native32Emu/issues/50#issuecomment-4814763251
- https://github.com/jiangxincode/Native32Emu/issues/50#issuecomment-4815095036

## Problem

The reported games played speech and sound effects but omitted the continuous background melodies present on original hardware. The failure had two independent causes:

1. The MP3 resource base offset was read from base + 0x18, which is the beginning of the encrypted header, instead of the actual base + 0x10 field. The resulting invalid address caused MP3 resource loading to fail before decoding began.
2. The non-standalone MP3 path was a stub that always returned failure, so correcting resource parsing alone would still leave libretro playback silent.

The existing audio model also could not reproduce the expected behavior completely:

- music and sound effects shared one pending buffer, so a new effect replaced existing audio;
- 0xFF infinite loops were reduced to a single playback;
- channel completion was tracked globally instead of per movie;
- standalone playback used one player, causing effects to interrupt music;
- truncating 11025 / 30 samples on every video frame accumulated timing drift.

## Solution

### Correct MP3 resource loading

- Read mp3_offset from the correct header field.
- Add checked offset arithmetic and strict range validation so malformed pointers and truncated resources fail safely.

### Decode MP3 in the platform-independent core

- Add Symphonia with only its pure-Rust MP3 feature enabled.
- Decode MP3 data to interleaved PCM and resample it to the active engine output rate.
- Preserve mono sources as stereo output by duplicating the channel.

### Implement channel-based playback and mixing

- Add a dedicated music channel and up to eight concurrent sound-effect channels.
- Mix music and RAW PCM effects with saturating output instead of replacing the previous buffer.
- Implement finite repeat counts and true 0xFF infinite looping.
- Give every playback channel a stable identifier and owner so movie timelines wait for their own sound and StopSounds only stops the intended channels.
- Keep separate music and sound-effect players in the standalone frontend.
- Use a fractional sample-frame remainder so 11025 Hz produces alternating 367/368-frame batches without long-term drift.

### Preserve audio across save states

- Store compressed MP3 or RAW source data together with the playback cursor, owner, channel ID, and remaining loop state.
- Re-decode active MP3 music during restore instead of serializing the much larger decoded PCM buffer.
- Bump the save-state format to version 2 because the audio state schema changed.

### Add regression coverage and documentation

- Add unit tests for sample budgeting, mixing, finite/infinite looping, resampling, and save-state restoration.
- Add a real-game regression test that verifies MP3 music, simultaneous RAW effects, looping beyond the original track end, and save-state restoration.
- Update the RetroArch audio support documentation.

## Changes

- crates/native32emu-core/src/file_loader.rs — correct and harden MP3 resource address parsing.
- crates/native32emu-core/src/audio_engine.rs — add MP3 decoding, resampling, channel mixing, looping, ownership, and audio state persistence.
- crates/native32emu-core/src/emulator.rs — track and release individual sound channels per movie.
- crates/native32emu-core/src/save_state.rs — bump the serialized state version.
- crates/native32emu-core/tests/smoke.rs — add the real MP3 playback regression.
- Cargo.toml, Cargo.lock, and crates/native32emu-core/Cargo.toml — add the MP3 decoder dependency.
- README.md — document MP3, looping, and simultaneous effect support.

## Verification

- cargo fmt --all -- --check ✓
- cargo clippy --workspace --all-targets -- -D warnings ✓
- cargo test --workspace ✓
- Real-game MP3 regression: background music remained active after 30 seconds, a RAW effect played concurrently and completed independently, and save-state restoration resumed the active music ✓
- Full local asset smoke test: 185 game/content files completed with zero failures; two pre-existing blank-frame warnings remained unchanged ✓
- Windows libretro release build ✓
- Windows standalone release build ✓
- Manual user verification in the affected game ✓
- GitHub CI: Check & Lint, CodeQL, SonarQube/SonarCloud, and GitGuardian Security Checks ✓

## Notes for reviewer

- Save states created with version 1 are intentionally rejected after this audio-state schema change.
- The implementation keeps encoded MP3 data in save states and decodes it again during restoration to keep serialized state size bounded.

