### PR TITLE
fix: play main timeline sound objects (#50)

### DIFF
--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -188,6 +188,13 @@ impl Emulator {
         if let Some(objects) = self.reader.get_frame(frame) {
             self.cur_frame_objects = objects.clone();
             self.sprites.update_for_frame(&objects);
+            for sound in objects
+                .iter()
+                .filter(|object| object.obj_type == ObjectType::Sound)
+                .map(|object| object.index)
+            {
+                self.audio.play_sound(&mut self.reader, sound, "");
+            }
         } else {
             log::warn!("Failed to load frame {}", frame);
             self.cur_frame_objects.clear();

--- a/crates/native32emu-core/tests/smoke.rs
+++ b/crates/native32emu-core/tests/smoke.rs
@@ -501,6 +501,29 @@ fn magical_adventure_mp3_music_decodes_mixes_and_loops() {
         "active MP3 channel was not restored from save state"
     );
 }
+
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn main_timeline_sound_objects_start_background_music() {
+    let dir = game_dir().expect("no game directory found");
+    for relative in ["ESPG/Basketba.smf", "EPUZ/Mouse.smf"] {
+        let game = dir.join(relative);
+        let mut emu = Emulator::from_path(game, 100).expect("load reported game");
+        emu.load_frame(1);
+
+        assert!(
+            emu.audio.is_playing(),
+            "{relative} did not start frame 1 music"
+        );
+        let samples: Vec<i16> = (0..30)
+            .flat_map(|_| emu.get_pending_audio_samples())
+            .collect();
+        assert!(
+            samples.iter().any(|sample| *sample != 0),
+            "{relative} frame 1 music decoded to silence"
+        );
+    }
+}
 /// Test ZIP file loading: a ZIP archive containing FHUI.smf should be extracted
 /// and the main menu loaded automatically.
 #[test]


### PR DESCRIPTION
## Summary

Related to #50. This PR intentionally keeps the issue open.

Handle main-timeline sound objects so games that start background music directly from a timeline frame can play it through the existing audio engine.

Reported in [issue comment 4823879810](https://github.com/jiangxincode/Native32Emu/issues/50#issuecomment-4823879810).

## Problem

`Basketba.smf` and `Mouse.smf` contain their background MP3 as a `Sound` object on the main timeline. The emulator parsed these objects but only started sounds referenced by movie frames, so both games remained silent even though their MP3 data decoded correctly.

## Solution

When a main timeline frame is loaded, pass each `ObjectType::Sound` entry to the existing audio engine. This uses the same sound value and playback behavior as movie-frame audio and preserves existing stop/mix semantics.

## Changes

- `crates/native32emu-core/src/emulator.rs` — play sound objects while loading main timeline frames.
- `crates/native32emu-core/tests/smoke.rs` — add an asset-backed regression test for Basketball and Mouse background music.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo test --workspace` ✓ (215 unit tests passed; asset-backed tests ignored by default)
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test -p native32emu-core --test smoke main_timeline_sound_objects_start_background_music -- --ignored` ✓
- Full local asset smoke suite: 9 passed, including `smoke_all_games` ✓

## Notes for reviewer

- README and docs already describe MP3 playback as supported; this restores that documented behavior and does not change the public interface.
- Please keep #50 open after merging so the reporter can continue verification.
