### PR TITLE
fix: preserve Basketball background music

### DIFF
--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -12,6 +12,15 @@ use crate::sprite_system::{MovieState, SpriteSystem};
 use anyhow::{Context, Result};
 use std::path::{Component, Path, PathBuf};
 
+fn timeline_sound_value(index: u16, loop_count: i16) -> u16 {
+    let repeat = if loop_count == i16::MAX {
+        0xFF
+    } else {
+        loop_count.clamp(0, 0xFE) as u16
+    };
+    (repeat << 8) | (index & 0xFF)
+}
+
 /// The platform-independent emulator core.
 ///
 /// This holds all the game simulation state and is shared by both the
@@ -191,9 +200,9 @@ impl Emulator {
             for sound in objects
                 .iter()
                 .filter(|object| object.obj_type == ObjectType::Sound)
-                .map(|object| object.index)
             {
-                self.audio.play_sound(&mut self.reader, sound, "");
+                let sound_value = timeline_sound_value(sound.index, sound.x);
+                self.audio.play_sound(&mut self.reader, sound_value, "");
             }
         } else {
             log::warn!("Failed to load frame {}", frame);

--- a/crates/native32emu-core/tests/smoke.rs
+++ b/crates/native32emu-core/tests/smoke.rs
@@ -504,6 +504,29 @@ fn magical_adventure_mp3_music_decodes_mixes_and_loops() {
 
 #[test]
 #[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn basketball_keeps_background_music_during_gameplay() {
+    let dir = game_dir().expect("no game directory found");
+    let game = dir.join("ESPG/Basketba.smf");
+    let mut emu = Emulator::from_path(game, 100).expect("load Basketball");
+    emu.load_frame(1);
+    for frame in 0..1_800 {
+        let pressed = if frame >= 50 && (frame - 50) % 45 < 3 {
+            vec![KEY_Z]
+        } else {
+            vec![]
+        };
+        emu.set_buttons(&pressed);
+        emu.tick();
+        let _ = emu.get_pending_audio_samples();
+    }
+
+    assert!(
+        emu.audio.is_playing(),
+        "Basketball background music stopped during repeated shots"
+    );
+}
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
 fn main_timeline_sound_objects_start_background_music() {
     let dir = game_dir().expect("no game directory found");
     for relative in ["ESPG/Basketba.smf", "EPUZ/Mouse.smf"] {


### PR DESCRIPTION
## Summary

- preserve the loop metadata stored on main-timeline sound objects
- translate Native32's 32767 loop sentinel to the audio engine's infinite-repeat value
- add a Basketball regression test that exercises repeated shots and verifies background music remains active

## Root cause

Main-timeline sound objects store their sound index and loop count separately. The loader previously passed only the sound index to the audio engine, so Basketball's background track was treated as a one-shot sound even though its timeline object specifies the 32767 infinite-loop sentinel.

## Verification

- manually verified with ESPG/Basketba.smf
- cargo test --all
- dedicated ignored asset test: Basketball_keeps_background_music_during_gameplay

Related report: https://github.com/jiangxincode/Native32Emu/issues/50#issuecomment-4826610067

This PR intentionally does not close issue #50.