### PR TITLE
fix: share save data across SSL scenes (#63)

### DIFF
--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -586,7 +586,15 @@ impl Emulator {
         // Load new file
         let data = std::fs::read(&fullpath)
             .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", fullpath.display(), e))?;
-        self.save_manager = SaveManager::new(&fullpath);
+        let is_ssl = |path: &Path| {
+            path.extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("ssl"))
+        };
+        // Consecutive SSL scenes belong to one game and share its save data.
+        if !is_ssl(&self.filename) || !is_ssl(&fullpath) {
+            self.save_manager = SaveManager::new(&fullpath);
+        }
         self.filename = fullpath;
         self.reader = Native32Reader::new(data);
         self.reader.init()?;

--- a/crates/native32emu-core/tests/smoke.rs
+++ b/crates/native32emu-core/tests/smoke.rs
@@ -13,6 +13,7 @@
 
 use std::path::{Path, PathBuf};
 
+use native32emu_core::action_vm::VmHost;
 use native32emu_core::emulator::Emulator;
 
 /// Number of frames to run per game before sampling the output.
@@ -279,6 +280,56 @@ fn gunfire_menu_advances_on_confirm() {
         !final_name.eq_ignore_ascii_case("GFSTART.SSL"),
         "menu did not advance after holding confirm: still on {final_name} \
          (selection animation appears frozen)"
+    );
+}
+
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn metal_storm_continue_loads_next_content() {
+    let dir = game_dir().expect("no game directory found");
+    let source_start = find_asset(&dir, "MSSTART.ssl").expect("MSSTART.ssl not found");
+    let source_over = find_asset(&dir, "MSOVER.ssl").expect("MSOVER.ssl not found");
+    let source_next = find_asset(&dir, "MSPLAY10.ssl").expect("MSPLAY10.ssl not found");
+
+    let temp = tempfile::tempdir().expect("create temporary game directory");
+    let metal_dir = temp.path().join("NA32SSL/ENGLISH/METAL");
+    std::fs::create_dir_all(&metal_dir).expect("create Metal Storm directory");
+    let game_over = metal_dir.join("MSOVER.ssl");
+    let game_start = metal_dir.join("MSSTART.ssl");
+    let next_game = metal_dir.join("MSPLAY10.ssl");
+    std::fs::copy(source_over, &game_over).expect("copy MSOVER.ssl");
+    std::fs::copy(source_start, &game_start).expect("copy MSSTART.ssl");
+    std::fs::copy(source_next, &next_game).expect("copy MSPLAY10.ssl");
+    std::fs::write(format!("{}.ssl_sav", game_start.display()), "|1|1|10|0|00")
+        .expect("seed Metal Storm save data");
+
+    let mut emu = Emulator::from_path(game_start, 100).expect("load Metal Storm start screen");
+    VmHost::get_url(
+        &mut emu,
+        "/NA32SSL /ENGLISH /METAL   /MSOVER.ssl",
+        "SSL+SSL_PlayNext",
+    );
+    emu.tick();
+    for frame in 0..240 {
+        let pressed = if (60..63).contains(&frame) {
+            vec![KEY_Z]
+        } else {
+            vec![]
+        };
+        emu.set_buttons(&pressed);
+        emu.tick();
+        emu.draw();
+    }
+
+    let final_name = emu
+        .filename
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("");
+    assert!(
+        final_name.eq_ignore_ascii_case("MSPLAY10.ssl"),
+        "continue loaded {final_name} instead of MSPLAY10.ssl: {:?}",
+        emu.vm.vars
     );
 }
 


### PR DESCRIPTION
## Summary

Addresses the first reported problem in #63: Metal Storm no longer hangs after the player loses and selects **Yes** to continue.

This PR intentionally does not close #63 because the Mission Express and Gun Fire reports remain unresolved.

## Problem

Metal Storm is implemented as a chain of `.SSL` scene files. The emulator created a new `SaveManager` every time `SSL_PlayNext` switched content, so each scene read and wrote a different `.ssl_sav` file.

When gameplay transitioned to `MSOVER.ssl`, the game-over scene could not read the save data written by the preceding scene. Its fallback data produced the invalid path `MSPLAY|0.SSL`; because that file does not exist, selecting **Yes** remained on the game-over screen indefinitely.

## Solution

Preserve the existing save manager for consecutive `.SSL`-to-`.SSL` transitions. These files are scenes within one multi-file game and must share save data. Transitions involving non-SSL content still create a new save manager, preserving isolation between separate games and entry points.

## Changes

- `crates/native32emu-core/src/emulator.rs` — share save data across consecutive SSL scenes.
- `crates/native32emu-core/tests/smoke.rs` — add a deterministic Metal Storm regression test that moves from `MSSTART.ssl` to `MSOVER.ssl`, selects **Yes**, and verifies `MSPLAY10.ssl` loads.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p native32emu-core --release --test smoke metal_storm_continue_loads_next_content -- --ignored --nocapture`
- Manual release-mode playthrough: lost a Metal Storm game, selected **Yes**, and confirmed the game loaded `MSPLAY10.SSL`.

## Regression proof

With the old per-scene save behavior temporarily restored, the new regression test fails and reports `MSPLAY|0.SSL`. With this fix applied, the same test passes and loads `MSPLAY10.ssl`.

## Scope

Only the first Metal Storm problem from #63 is addressed. The Mission Express and Gun Fire problems are deliberately left for follow-up work.
