### PR TITLE
fix: accumulate MP3 samples correctly in decode_mp3

### DIFF
--- a/crates/native32emu-core/src/audio_engine.rs
+++ b/crates/native32emu-core/src/audio_engine.rs
@@ -686,6 +686,7 @@ fn decode_mp3(data: &[u8], output_rate: u32) -> anyhow::Result<Vec<i16>> {
     let mut decoded = Vec::new();
     let mut sample_rate = 0;
     let mut channel_count = 0;
+    let mut temp_buf = Vec::new();
     loop {
         let packet = match format.next_packet() {
             Ok(Some(packet)) => packet,
@@ -725,7 +726,10 @@ fn decode_mp3(data: &[u8], output_rate: u32) -> anyhow::Result<Vec<i16>> {
                 "MP3 stream changed audio format while decoding"
             ));
         }
-        audio.copy_to_vec_interleaved(&mut decoded);
+        // Use temp_buf to accumulate samples, then extend decoded
+        temp_buf.clear();
+        audio.copy_to_vec_interleaved(&mut temp_buf);
+        decoded.extend_from_slice(&temp_buf);
     }
 
     if sample_rate == 0 || channel_count == 0 || decoded.is_empty() {


### PR DESCRIPTION
## Problem

Background music stopped playing in RetroArch (libretro) builds after upgrading symphonia from 0.5.5 to 0.6.0. The standalone version was unaffected.

Related: https://github.com/jiangxincode/Native32Emu/issues/50#issuecomment-4849284070

## Root Cause

The `copy_to_vec_interleaved()` method in symphonia 0.6.0 changed its behavior. According to the documentation:

> "The vector is resized such that the length of the vector after the copy is the exact number of samples copied."

This means the method **resets** the destination vector size instead of appending. In the `decode_mp3()` loop, each call to `audio.copy_to_vec_interleaved(&mut decoded)` was overwriting all previously decoded samples, leaving only the last packets audio data.

```rust
// Before fix (broken in symphonia 0.6.0)
loop {
    // ... decode packet ...
    audio.copy_to_vec_interleaved(&mut decoded);  // Overwrites previous packets!
}
```

## Why Standalone Was Unaffected

The standalone version uses `rodio` for MP3 playback (`#[cfg(feature = "standalone")]` branch), which doesnt use the `decode_mp3()` function. Only the libretro build uses this function for audio decoding.

## Solution

Use a temporary buffer to receive each `copy_to_vec_interleaved()` call, then append to the main vector:

```rust
let mut temp_buf = Vec::new();
loop {
    // ... decode packet ...
    temp_buf.clear();
    audio.copy_to_vec_interleaved(&mut temp_buf);  // Write to temp buffer
    decoded.extend_from_slice(&temp_buf);           // Append to main vector
}
```

## Testing

All 215 unit tests pass. The `magical_adventure_mp3_music_decodes_mixes_and_loops` integration test (which specifically tests MP3 music decoding and playback) passes successfully.