### PR TITLE
fix: fire truck loses control after jump in Mission Express firefighter stages

### DIFF
--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -254,7 +254,7 @@ impl Emulator {
         let movie_advancements: Vec<(String, isize)> = {
             let mut advancements = Vec::new();
             for (name, movie) in self.sprites.iter_mut() {
-                if !movie.playing || movie.next_frame.is_some() || movie.sound_channel.is_some() {
+                if !movie.playing || movie.next_frame.is_some() {
                     continue;
                 }
                 let movie_frames = self.reader.get_movie(movie.movie);
@@ -594,6 +594,14 @@ impl Emulator {
         // Consecutive SSL scenes belong to one game and share its save data.
         if !is_ssl(&self.filename) || !is_ssl(&fullpath) {
             self.save_manager = SaveManager::new(&fullpath);
+        }
+        if !fullpath.starts_with(&self.content_root) {
+            self.content_root = self
+                .content_root
+                .ancestors()
+                .find(|ancestor| fullpath.starts_with(ancestor))
+                .context("switched content has no common root with the initial content")?
+                .to_path_buf();
         }
         self.filename = fullpath;
         self.reader = Native32Reader::new(data);

--- a/crates/native32emu-core/src/sprite_system.rs
+++ b/crates/native32emu-core/src/sprite_system.rs
@@ -112,9 +112,6 @@ impl SpriteSystem {
             if !movie.playing || movie.next_frame.is_some() {
                 continue;
             }
-            if movie.sound_channel.is_some() {
-                continue;
-            }
             // Half framerate: advance every other tick
             if tick_count.is_multiple_of(2) {
                 movie.next_frame = Some(movie.frame as isize + 1);
@@ -334,6 +331,19 @@ mod tests {
         assert!(!ms.cloned);
         assert!(ms.sound_channel.is_none());
         assert_eq!(ms.next_frame, Some(0));
+    }
+
+    #[test]
+    fn test_sound_does_not_pause_movie_timeline() {
+        let mut ss = SpriteSystem::new();
+        let mut movie = MovieState::new(1, 0, 0, 0);
+        movie.next_frame = None;
+        movie.sound_channel = Some(7);
+        ss.insert("movie".to_string(), movie);
+
+        ss.tick(2);
+
+        assert_eq!(ss.get("movie").unwrap().next_frame, Some(1));
     }
 
     #[test]

--- a/crates/native32emu-core/tests/smoke.rs
+++ b/crates/native32emu-core/tests/smoke.rs
@@ -576,6 +576,67 @@ fn basketball_keeps_background_music_during_gameplay() {
         "Basketball background music stopped during repeated shots"
     );
 }
+
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn mission_express_fire1_recovers_control_after_jump() {
+    let dir = game_dir().expect("no game directory found");
+    let game = find_asset(&dir, "FIRE1.SSL").expect("FIRE1.SSL not found");
+    let mut emu = Emulator::from_path(game, 100).expect("load Mission Express Fire1");
+
+    let mut saw_uncontrollable_jump = false;
+    for frame in 0..360 {
+        emu.set_buttons(&[]);
+        emu.tick();
+        let _ = emu.get_pending_audio_samples();
+        if frame == 300 {
+            let jump_frame = emu.vm.vars["pcarsf5"].parse::<u32>().unwrap();
+            emu.vm.vars.insert("pcarstate".into(), "0".into());
+            emu.vm.vars.insert("barstate".into(), "7".into());
+            VmHost::goto_frame(&mut emu, "pcar", jump_frame, true);
+        }
+        if frame > 300
+            && emu
+                .vm
+                .vars
+                .get("pcarstate")
+                .is_some_and(|state| state == "0")
+        {
+            saw_uncontrollable_jump = true;
+        }
+    }
+
+    assert!(saw_uncontrollable_jump, "test did not enter the jump state");
+    assert_eq!(
+        emu.vm.vars.get("pcarstate").map(String::as_str),
+        Some("1"),
+        "fire truck did not return to its controllable state after the jump"
+    );
+}
+
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn mission_express_save_state_survives_cross_directory_content_switch() {
+    let dir = game_dir().expect("no game directory found");
+    let game = dir.join("EPOP/EExpress.smf");
+    let mut emu = Emulator::from_path(game, 100).expect("load Mission Express launcher");
+
+    emu.frame_player.take_next_frame();
+    emu.frame_player.playing = false;
+    emu.content_loader
+        .queue_load("/NA32SSL /ENGLISH /MEXPRESS/FIRE1.SSL");
+    emu.tick();
+
+    let mut state = vec![0; emu.serialize_size()];
+    emu.serialize(&mut state)
+        .expect("save state after switching from EPOP to NA32SSL");
+    emu.deserialize(&state)
+        .expect("restore state after switching from EPOP to NA32SSL");
+    assert_eq!(
+        emu.filename.file_name().and_then(|name| name.to_str()),
+        Some("FIRE1.SSL")
+    );
+}
 #[test]
 #[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
 fn main_timeline_sound_objects_start_background_music() {


### PR DESCRIPTION
## Summary

Fix the fire truck becoming uncontrollable after the big jump in Mission Express firefighter stages (Issue #63, problem 2).

## Root Cause

The fire truck glitching across the map was caused by two related issues:

1. **Movie timeline frozen by sound effects**: When a sound was playing (`sound_channel.is_some()`), the movie advancement logic in both `emulator.rs` and `sprite_system.rs` would skip frame advancement. In the firefighter stages, playing the jump sound effect would freeze the truck's animation timeline, causing the game logic to lose synchronization with the visual state — resulting in the truck becoming uncontrollable.

2. **Cross-directory content path resolution**: When switching from a game launcher (e.g., `EExpress.smf` in `EPOP/`) to a stage file (e.g., `FIRE1.SSL` in `NA32SSL/ENGLISH/MEXPRESS/`), the `content_root` was not updated. This caused file path resolution to fail for assets in the new directory.

## Changes

- **`emulator.rs`**: Removed `movie.sound_channel.is_some()` from the movie advancement check; added `content_root` update logic when switching to content outside the initial root directory.
- **`sprite_system.rs`**: Removed the corresponding `sound_channel` check from `SpriteSystem::tick()`.
- **Tests**: Added unit test proving sound does not pause movie timeline, plus smoke tests for fire-truck control recovery and cross-directory save state round-trip.

## Verification

- All unit tests pass (221 tests)
- User has verified the fix: fire truck no longer glitches after the jump
- Added regression test `mission_express_fire1_recovers_control_after_jump` to prevent future regressions

Closes #63 (second problem only — fire truck失控 in firefighter stages)