### PR TITLE
fix: restore Pirate bomb lifecycle (#68)

### DIFF
--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -869,9 +869,9 @@ impl VmHost for Emulator {
             let mut new_state = MovieState::new(orig.movie, orig.x, orig.y, depth as u16);
             new_state.frame = 0;
             new_state.visible = true;
-            new_state.playing = orig.playing;
+            new_state.playing = true;
             new_state.cloned = true;
-            new_state.next_frame = Some(orig.frame as isize);
+            new_state.next_frame = Some(0);
             self.sprites.insert(dest.to_string(), new_state);
         }
     }

--- a/crates/native32emu-core/tests/smoke.rs
+++ b/crates/native32emu-core/tests/smoke.rs
@@ -714,3 +714,53 @@ fn zip_file_loads_fhui() {
         "ZIP-loaded FHUI.smf produced a blank frame"
     );
 }
+/// A placed Pirate bomb must start at the template's first visible frame.
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn pirate_bomb_plays_and_explodes() {
+    let dir = game_dir().expect("no game directory found");
+    let game = dir.join("EPOP/Epirate.smf");
+
+    let tap_frames = [80, 220, 360, 500, 640];
+    let emu = run_scripted(&game, 650, |frame| {
+        if tap_frames
+            .iter()
+            .any(|start| (*start..*start + 3).contains(&frame))
+        {
+            vec![KEY_Z]
+        } else {
+            vec![]
+        }
+    })
+    .expect("run Pirate");
+
+    let bomb = emu.sprites.get("B1").expect("bomb clone was not created");
+    assert!(bomb.visible, "placed bomb clone is hidden");
+    assert!(bomb.playing, "placed bomb clone is not playing");
+    assert!(
+        bomb.frame < 10,
+        "placed bomb started at the hidden template frame: {}",
+        bomb.frame
+    );
+
+    let emu = run_scripted(&game, 770, |frame| {
+        if tap_frames
+            .iter()
+            .any(|start| (*start..*start + 3).contains(&frame))
+        {
+            vec![KEY_Z]
+        } else {
+            vec![]
+        }
+    })
+    .expect("run Pirate through bomb explosion");
+
+    assert!(
+        emu.sprites.get("B1").is_none(),
+        "bomb clone did not remove itself after exploding"
+    );
+    assert_eq!(
+        emu.vm.vars.get("btotal").map(String::as_str),
+        Some("|00000")
+    );
+}

--- a/docs/Game-Compatibility.md
+++ b/docs/Game-Compatibility.md
@@ -69,7 +69,7 @@ All 84 Native32 games in the test suite load and run without fatal errors. Each 
 | 2 | 极速任务 | Express | tmp/native32_game/EPOP/EExpress.smf | ![极速任务](images/EPOP/EExpress.png) | 类赛车多角色游戏，含城市、高速、荒野、F1 赛道场景，有障碍物和道具。 | ✅ Pass |
 | 3 | 枪火 | Gun Fire | tmp/native32_game/EPOP/EGUNFIRE.smf | ![枪火](images/EPOP/EGUNFIRE.png) | 横版射击（STG）游戏。骑上心爱的机车，拿起火枪，在枪火纷飞的世界去打击黑社会，对抗独裁者，消灭生化怪兽。 | ✅ Pass |
 | 4 | 钢铁风暴 | Metal Storm | tmp/native32_game/EPOP/EMETAL.smf | ![钢铁风暴](images/EPOP/EMETAL.png) | 四向自由卷轴射击游戏。游戏虚构了一个近未来的世界，军事科技以现实世界科技为基础有一定发展，武器与现实世界相似。 | ✅ Pass |
-| 5 | 海盗 | Pirate | tmp/native32_game/EPOP/Epirate.smf | ![海盗](images/EPOP/Epirate.png) | 以"炸弹人"为原型的休闲桌面（PUZ）游戏。小海盗雷克获得藏宝图后开启冒险，炸弹可正常放置、显示并自动爆炸。 | ✅ Pass |
+| 5 | 海盗 | Pirate | tmp/native32_game/EPOP/Epirate.smf | ![海盗](images/EPOP/Epirate.png) | 以"炸弹人"为原型的休闲桌面（PUZ）游戏。小海盗雷克获得藏宝图后开启冒险。 | ✅ Pass |
 | 6 | 符文之语 | Rune Word | tmp/native32_game/EPOP/ERuneWod.smf | ![符文之语](images/EPOP/ERuneWod.png) | 类似于对对碰的游戏。年轻的魔法学徒艾莉进入炼金房修炼，在大魔导师雷斯林的指导下学习一个又一个的魔法。各种符文代表不同属性的魔力。 | ✅ Pass |
 | 7 | 风暴之翼 | Storm | tmp/native32_game/EPOP/ESTORM.smf | ![风暴之翼](images/EPOP/ESTORM.png) | 纵版射击（STG）游戏。王牌飞行员 Jason 和 Blanche 深入 239 区侦察，遭遇敌方终极战机及隐藏秘密武器。 | ✅ Pass |
 | 8 | 汉语学堂一 | School 1 | tmp/native32_game/EPOP/SCHOOL1.smf | ![汉语学堂一](images/EPOP/SCHOOL1.png) | 中英文双语学习（ELA）软件，全 3D 图画，涵盖服装、水果、室内、身体、头部、野餐六大类。 | ✅ Pass |

--- a/docs/Game-Compatibility.md
+++ b/docs/Game-Compatibility.md
@@ -69,7 +69,7 @@ All 84 Native32 games in the test suite load and run without fatal errors. Each 
 | 2 | 极速任务 | Express | tmp/native32_game/EPOP/EExpress.smf | ![极速任务](images/EPOP/EExpress.png) | 类赛车多角色游戏，含城市、高速、荒野、F1 赛道场景，有障碍物和道具。 | ✅ Pass |
 | 3 | 枪火 | Gun Fire | tmp/native32_game/EPOP/EGUNFIRE.smf | ![枪火](images/EPOP/EGUNFIRE.png) | 横版射击（STG）游戏。骑上心爱的机车，拿起火枪，在枪火纷飞的世界去打击黑社会，对抗独裁者，消灭生化怪兽。 | ✅ Pass |
 | 4 | 钢铁风暴 | Metal Storm | tmp/native32_game/EPOP/EMETAL.smf | ![钢铁风暴](images/EPOP/EMETAL.png) | 四向自由卷轴射击游戏。游戏虚构了一个近未来的世界，军事科技以现实世界科技为基础有一定发展，武器与现实世界相似。 | ✅ Pass |
-| 5 | 海盗 | Pirate | tmp/native32_game/EPOP/Epirate.smf | ![海盗](images/EPOP/Epirate.png) | 以"炸弹人"为原型的休闲桌面（PUZ）游戏。小海盗雷克获得藏宝图后开启冒险。 | ✅ Pass |
+| 5 | 海盗 | Pirate | tmp/native32_game/EPOP/Epirate.smf | ![海盗](images/EPOP/Epirate.png) | 以"炸弹人"为原型的休闲桌面（PUZ）游戏。小海盗雷克获得藏宝图后开启冒险，炸弹可正常放置、显示并自动爆炸。 | ✅ Pass |
 | 6 | 符文之语 | Rune Word | tmp/native32_game/EPOP/ERuneWod.smf | ![符文之语](images/EPOP/ERuneWod.png) | 类似于对对碰的游戏。年轻的魔法学徒艾莉进入炼金房修炼，在大魔导师雷斯林的指导下学习一个又一个的魔法。各种符文代表不同属性的魔力。 | ✅ Pass |
 | 7 | 风暴之翼 | Storm | tmp/native32_game/EPOP/ESTORM.smf | ![风暴之翼](images/EPOP/ESTORM.png) | 纵版射击（STG）游戏。王牌飞行员 Jason 和 Blanche 深入 239 区侦察，遭遇敌方终极战机及隐藏秘密武器。 | ✅ Pass |
 | 8 | 汉语学堂一 | School 1 | tmp/native32_game/EPOP/SCHOOL1.smf | ![汉语学堂一](images/EPOP/SCHOOL1.png) | 中英文双语学习（ELA）软件，全 3D 图画，涵盖服装、水果、室内、身体、头部、野餐六大类。 | ✅ Pass |


### PR DESCRIPTION
## Summary

Relates to #68.

This PR restores the complete bomb lifecycle in the EPOP Pirate game: placed bombs now appear from their first visible frame, play their timeline, explode automatically, and remove themselves when the explosion finishes. This intentionally does not auto-close issue #68.

## Problem

Pirate uses a hidden `BOMB` movie as a template and creates each placed bomb with `CloneSprite`. The template has already reached frame 49 and is stopped by the time gameplay clones it.

The emulator previously copied both pieces of runtime state into the new instance:

- `next_frame` was initialized from the template's current frame, so the clone started at the hidden final frame instead of the visible bomb frame.
- `playing` was inherited as `false`, so even after making the first frame visible, the bomb timeline never advanced and the explosion actions never ran.

As a result, the game logic registered a bomb, but it was initially invisible; after the first partial fix it became visible but never exploded.

## Solution

Initialize every `CloneSprite` instance as a fresh, active movie clip:

- Start at frame index `0` rather than the source instance's current frame.
- Set `playing` to `true` so timeline actions execute.
- Preserve the source movie resource, position, requested clone depth, visibility behavior, and cloned-instance lifetime semantics.

This lets Pirate's existing bomb movie timeline drive animation, explosion, bookkeeping, and removal without game-specific special cases.

## Changes

- `crates/native32emu-core/src/emulator.rs` — start cloned sprites from frame 0 in the playing state.
- `crates/native32emu-core/tests/smoke.rs` — add a deterministic real-asset regression test that verifies the bomb is created visible and playing, then explodes, removes itself, and clears `btotal`.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo build --workspace --release` ✓
- `cargo test --workspace` ✓
- `NATIVE32_GAME_DIR=E:\Code\Native32Emu\tmp\native32_game cargo test -p native32emu-core --release --test smoke pirate_bomb_plays_and_explodes -- --ignored --nocapture` ✓
- Regression test confirmed to fail on the old behavior with bomb frame 49 ✓

## Notes for reviewer

- The fix is implemented at `CloneSprite` semantics rather than special-casing Pirate.
- The regression test uses `EPOP/Epirate.smf` and checks both the visible placement phase and the completed explosion/removal phase.
- The PR uses `Relates to #68`, not an auto-closing keyword; issue #68 remains open after merge.