### PR TITLE
ci: add Linux aarch64 release builds (#74)

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -29,6 +29,9 @@ jobs:
           - platform: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             artifact: native32-emu-linux-x86_64
+          - platform: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            artifact: native32-emu-linux-aarch64
           - platform: macos-latest
             target: x86_64-apple-darwin
             artifact: native32-emu-macos-x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
           - platform: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             artifact: native32-emu-linux-x86_64
+          - platform: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            artifact: native32-emu-linux-aarch64
           - platform: macos-latest
             target: x86_64-apple-darwin
             artifact: native32-emu-macos-x86_64
@@ -271,6 +274,7 @@ jobs:
 
             ### Standalone emulator
             - **Linux x86_64**: `native32-emu-linux-x86_64.tar.gz`
+            - **Linux aarch64**: `native32-emu-linux-aarch64.tar.gz`
             - **macOS x86_64**: `native32-emu-macos-x86_64.tar.gz`
             - **macOS aarch64**: `native32-emu-macos-aarch64.tar.gz`
             - **Windows x86_64**: `native32-emu-windows-x86_64.zip`


### PR DESCRIPTION
## Summary

Related to #74.

Add native Linux aarch64 builds to the nightly and tagged release workflows without changing the libretro buildbot configuration.

## Problem

GitHub releases currently provide Linux x86_64 artifacts but no Linux aarch64 artifacts. Users running aarch64 Linux systems therefore cannot download either the standalone emulator or the libretro core from a release.

## Solution

Add `aarch64-unknown-linux-gnu` to both GitHub Actions build matrices using GitHub's native `ubuntu-24.04-arm` runner. The existing matrix steps then build and package both the standalone emulator and the libretro core without requiring a cross-compilation toolchain.

The GitLab CI configuration remains unchanged until the libretro infrastructure provides an official `rust-linux-aarch64.yml` template.

## Changes

- `.github/workflows/nightly-build.yml` — publish nightly Linux aarch64 standalone and libretro artifacts.
- `.github/workflows/release.yml` — publish tagged Linux aarch64 artifacts and document the standalone download.

## Verification

- YAML parsing ✓
- `git diff --check` ✓
- `cargo check -p native32emu -p native32emu-libretro` ✓
- Pre-commit `cargo clippy -- -D warnings` ✓
- Pre-commit `cargo fmt -- --check` ✓
- Pre-push `cargo test --all` ✓

## Notes for reviewer

- This PR intentionally references but does not automatically close #74.
- `.gitlab-ci.yml` is intentionally excluded pending upstream Rust Linux aarch64 template support.
