### PR TITLE
libretro: add webOS to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/rust-android-jni.yml'
 
+  # webOS
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/rust-webos.yml'
+
 stages:
   - build-prepare
   - build-shared
@@ -95,4 +99,10 @@ libretro-build-ios-arm64:
 libretro-build-tvos-arm64:
   extends:
     - .libretro-rust-tvos-arm64-default
+    - .core-defs
+
+# webOS
+libretro-build-webos-armv7a:
+  extends:
+    - .libretro-rust-webos-armv7a-default
     - .core-defs


### PR DESCRIPTION
As requested by a webOS user. Adds it to the libretro buildbot CI.