### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,23 @@ libretro-build-linux-x64:
     - .libretro-rust-linux-x64-default
     - .core-defs
 
+# Linux aarch64
+# Cross-compiled from the same image as the x64 job, the way that image already
+# cross-compiles the Apple and Android arm64 targets. There is no
+# rust-linux-aarch64.yml template yet (libretro/libretro-super#2030) and the
+# rust image is amd64-only, so the target and its linker are added here.
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-rust-linux-x64
+    - .core-defs
+  variables:
+    TARGET_ARCH: aarch64-unknown-linux-gnu
+    STRIP: aarch64-linux-gnu-strip
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+  before_script:
+    - apt-get update -qy && apt-get install -yq gcc-aarch64-linux-gnu
+    - rustup target add aarch64-unknown-linux-gnu
+
 # macOS 64-bit
 libretro-build-osx-x64:
   extends:


### PR DESCRIPTION
Adds a `libretro-build-linux-aarch64` job so the core lands in `nightly/linux/aarch64/` on the buildbot, where it is currently missing.

### Why it is not a one-liner

There is no `rust-linux-aarch64.yml` template in ci-templates — only `rust-linux-x64.yml` — and `libretro-build-rust` is `FROM libretro-build-amd64-ubuntu`, so there is no native aarch64 image to point at either. I raised that gap as libretro/libretro-super#2030.

So this job cross-compiles from the same image the x64 job already uses, in the style that image already uses for its other arm64 targets (it sets `CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER`, `CARGO_TARGET_AARCH64_APPLE_IOS_LINKER` and so on): add the target, point `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER` at `aarch64-linux-gnu-gcc`, and override `STRIP`, since the template's default `strip` is host binutils (`rust-webos.yml` already does the same for its ARM targets).

`.libretro-rust-linux-x64` is extended rather than `-default`, because that is what pins `TARGET_ARCH` to x86_64. If a `rust-linux-aarch64.yml` template ever lands, this job collapses to an `extends:` line.

### Tested on real aarch64 hardware

Built natively on an aarch64 Linux machine (Snapdragon 7c / SC7180, postmarketOS), Rust 1.97.1, target `aarch64-unknown-linux-gnu`:

* **no source changes needed** — `cargo build --release --target aarch64-unknown-linux-gnu` is clean across the workspace
* `libnative32emu.so` builds as an ELF 64-bit LSB shared object, ARM aarch64

**This is build-verified only.** The core takes `smf|sgm|ssl|zip` content, which I have no legitimate way to obtain, so I could not run it in RetroArch — unlike the other aarch64 jobs I have sent, where I booted a game first. If you have a redistributable sample I am happy to run it and report back.

**What I could not test:** I built natively on aarch64, whereas this job cross-compiles from x86_64. I also cannot run GitLab pipelines from a GitHub PR, so the job itself has not been executed by CI.
