### PR TITLE
fix: add libretro return action (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ and all command-line options.
 
 Install **Native32 (Native32Emu)** from RetroArch's Core Downloader, or install
 the release files manually, then load a supported game through **Load Content**.
+Press RetroPad **Select** to return from a ZIP-loaded game to its FHUI menu;
+press it again on that menu, or while running a directly loaded file, to close
+the core.
 
 See the [RetroArch Core](docs/RetroArch-Core.md) guide for installation,
 supported platforms and features, RetroPad mapping, core options, and cheats.

--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -58,7 +58,7 @@ pub struct Emulator {
     active_video_name: Option<String>,
     /// The initial file loaded at startup (typically FHUI.smf from a ZIP).
     /// Set to None when the user loaded a game directly (not from a menu).
-    /// Used to support "return to menu" on ESC.
+    /// Used to support the frontends' shared back action.
     pub initial_file: Option<PathBuf>,
     /// When true, cutscene videos are skipped automatically as soon as they
     /// become active, instead of waiting for the user to press A/B.
@@ -94,8 +94,8 @@ impl Emulator {
 
         let save_manager = SaveManager::new(&game_path);
 
-        // When loaded from a ZIP, remember the FHUI.smf path so pressing ESC
-        // in a game returns to the menu instead of exiting.
+        // When loaded from a ZIP, remember the FHUI.smf path so the frontend's
+        // back action can return to the menu instead of exiting.
         let initial_file = if is_zip {
             Some(game_path.clone())
         } else {
@@ -154,6 +154,23 @@ impl Emulator {
         self.initial_file
             .as_ref()
             .is_some_and(|p| *p != self.filename)
+    }
+
+    /// Return to the initial ZIP menu when one is available.
+    ///
+    /// Returns `true` after reloading the menu and `false` when the frontend
+    /// should handle the back action by ending the current emulation session.
+    pub fn try_return_to_menu(&mut self) -> Result<bool> {
+        if !self.can_return_to_menu() {
+            return Ok(false);
+        }
+
+        let menu_path = self
+            .initial_file
+            .clone()
+            .expect("a returnable menu must have an initial file");
+        self.reload_from_path(menu_path)?;
+        Ok(true)
     }
 
     /// Reload the emulator from the given file path, performing a full state

--- a/crates/native32emu-core/tests/smoke.rs
+++ b/crates/native32emu-core/tests/smoke.rs
@@ -714,6 +714,49 @@ fn zip_file_loads_fhui() {
         "ZIP-loaded FHUI.smf produced a blank frame"
     );
 }
+
+/// The shared back action should return a ZIP-loaded child game to FHUI.
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn back_action_returns_to_zip_menu() {
+    let dir = match game_dir() {
+        Some(d) => d,
+        None => {
+            eprintln!("skipping: no game directory found (set NATIVE32_GAME_DIR)");
+            return;
+        }
+    };
+    let Some(zip_path) = dir
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|root| root.join("tmp").join("native32_game.zip"))
+        .filter(|p| p.exists())
+    else {
+        eprintln!("skipping: native32_game.zip not found");
+        return;
+    };
+
+    let mut emu = Emulator::from_path(zip_path, 100).expect("failed to load ZIP game");
+    let menu_path = emu.filename.clone();
+    let mut games = Vec::new();
+    collect_games(
+        menu_path.parent().expect("FHUI path has no parent"),
+        &mut games,
+    );
+    let child_game = games
+        .into_iter()
+        .find(|path| *path != menu_path)
+        .expect("ZIP package contains no child game");
+
+    emu.reload_from_path(child_game)
+        .expect("failed to load child game");
+    assert!(emu.try_return_to_menu().expect("back action failed"));
+    assert_eq!(emu.filename, menu_path);
+    assert!(!emu
+        .try_return_to_menu()
+        .expect("back action at the menu failed"));
+}
+
 /// A placed Pirate bomb must start at the template's first visible frame.
 #[test]
 #[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]

--- a/crates/native32emu-libretro/src/libretro/api.rs
+++ b/crates/native32emu-libretro/src/libretro/api.rs
@@ -10,9 +10,13 @@ use native32emu_core::emulator::Emulator;
 use native32emu_core::input_handler::InputHandler;
 use std::ffi::{c_void, CStr};
 use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Global emulator instance
 static mut EMULATOR: Option<Emulator> = None;
+
+/// Previous RetroPad Select state, used to trigger the back action once per press.
+static RETURN_BUTTON_DOWN: AtomicBool = AtomicBool::new(false);
 
 /// Get a reference to the emulator
 unsafe fn get_emulator() -> &'static Emulator {
@@ -88,6 +92,7 @@ pub extern "C" fn retro_deinit() {
     unsafe {
         EMULATOR = None;
     }
+    RETURN_BUTTON_DOWN.store(false, Ordering::Relaxed);
     log::info!("Native32Emu libretro core deinitialized");
 }
 
@@ -122,6 +127,7 @@ pub extern "C" fn retro_set_controller_port_device(_port: u32, _device: u32) {
 #[no_mangle]
 pub extern "C" fn retro_load_game(info: *const retro_game_info) -> bool {
     unsafe {
+        RETURN_BUTTON_DOWN.store(false, Ordering::Relaxed);
         let game_info = &*info;
 
         // Check if path is valid
@@ -183,6 +189,7 @@ pub extern "C" fn retro_unload_game() {
     unsafe {
         EMULATOR = None;
     }
+    RETURN_BUTTON_DOWN.store(false, Ordering::Relaxed);
     log::info!("Game unloaded");
 }
 
@@ -224,11 +231,28 @@ pub extern "C" fn retro_run() {
         // 1. Poll input
         callbacks::input_poll();
 
-        // 2. Query joypad button state and convert to Native32 keycodes
+        // 2. Handle the frontend-level back action on the Select press edge.
+        if return_button_just_pressed(0) {
+            match emu.try_return_to_menu() {
+                Ok(true) => log::info!("Returned to the ZIP game menu"),
+                Ok(false) => {
+                    log::info!("Requesting frontend shutdown");
+                    callbacks::environment(RETRO_ENVIRONMENT_SHUTDOWN, ptr::null_mut());
+                    return;
+                }
+                Err(e) => {
+                    log::error!("Failed to reload the ZIP game menu: {}", e);
+                    callbacks::environment(RETRO_ENVIRONMENT_SHUTDOWN, ptr::null_mut());
+                    return;
+                }
+            }
+        }
+
+        // 3. Query joypad button state and convert to Native32 keycodes
         let buttons = query_joypad_buttons(0);
         emu.set_buttons(&buttons);
 
-        // 3. During a cutscene, suppress game input and
+        // 4. During a cutscene, suppress game input and
         // allow the A or B button to skip the logo/cutscene videos instead.
         // When auto-skip is enabled, skip as soon as the cutscene starts.
         if emu.is_cutscene_active()
@@ -239,19 +263,19 @@ pub extern "C" fn retro_run() {
             emu.skip_cutscene();
         }
 
-        // 4. Execute one tick of emulation
+        // 5. Execute one tick of emulation
         emu.tick();
 
-        // 5. Render the frame
+        // 6. Render the frame
         emu.draw();
 
-        // 6. Output video frame
+        // 7. Output video frame
         let framebuffer = emu.get_framebuffer();
         let (width, height) = emu.get_resolution();
         let pitch = width as usize * 4; // XRGB8888 = 4 bytes per pixel
         callbacks::video_refresh(framebuffer.as_ptr() as *const c_void, width, height, pitch);
 
-        // 7. Output audio samples
+        // 8. Output audio samples
         let audio_samples = emu.get_pending_audio_samples();
         if !audio_samples.is_empty() {
             callbacks::audio_sample_batch(
@@ -544,6 +568,13 @@ fn register_input_descriptors() {
             id: RETRO_DEVICE_ID_JOYPAD_B,
             description: c"B Button".as_ptr(),
         },
+        retro_input_descriptor {
+            port: 0,
+            device: RETRO_DEVICE_JOYPAD,
+            index: 0,
+            id: RETRO_DEVICE_ID_JOYPAD_SELECT,
+            description: c"Return / Exit".as_ptr(),
+        },
         // Terminator
         retro_input_descriptor {
             port: 0,
@@ -558,6 +589,18 @@ fn register_input_descriptors() {
         RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS,
         descriptors.as_ptr() as *mut c_void,
     );
+}
+
+/// Return whether the RetroPad Select button was newly pressed this frame.
+fn return_button_just_pressed(port: u32) -> bool {
+    let is_down =
+        callbacks::input_state(port, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT) != 0;
+    let was_down = RETURN_BUTTON_DOWN.swap(is_down, Ordering::Relaxed);
+    is_rising_edge(is_down, was_down)
+}
+
+fn is_rising_edge(is_down: bool, was_down: bool) -> bool {
+    is_down && !was_down
 }
 
 /// Query joypad button state and convert to Native32 keycodes.
@@ -591,4 +634,17 @@ fn query_joypad_buttons(port: u32) -> Vec<u16> {
     }
 
     buttons
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_rising_edge;
+
+    #[test]
+    fn rising_edge_only_fires_on_initial_press() {
+        assert!(!is_rising_edge(false, false));
+        assert!(is_rising_edge(true, false));
+        assert!(!is_rising_edge(true, true));
+        assert!(!is_rising_edge(false, true));
+    }
 }

--- a/crates/native32emu/src/main.rs
+++ b/crates/native32emu/src/main.rs
@@ -199,17 +199,16 @@ fn main() -> Result<()> {
         if esc_cooldown > 0 {
             esc_cooldown -= 1;
         } else if window.is_key_down(minifb::Key::Escape) {
-            if emu.can_return_to_menu() {
-                if let Some(menu_path) = emu.initial_file.clone() {
-                    if let Err(e) = emu.reload_from_path(menu_path) {
-                        log::error!("Failed to reload menu: {}", e);
-                        break;
-                    }
+            match emu.try_return_to_menu() {
+                Ok(true) => {
+                    esc_cooldown = 15; // ~0.5s at 30fps, enough for key release
+                    continue;
                 }
-                esc_cooldown = 15; // ~0.5s at 30fps, enough for key release
-                continue;
-            } else {
-                break;
+                Ok(false) => break,
+                Err(e) => {
+                    log::error!("Failed to reload menu: {}", e);
+                    break;
+                }
             }
         }
 

--- a/docs/RetroArch-Core.md
+++ b/docs/RetroArch-Core.md
@@ -54,6 +54,18 @@ platform-specific installation requirements:
 | D-Pad Down | `0x1e00` | Down |
 | A (SNES East) | `0x8800` | B / Menu |
 | B (SNES South) | `0x4000` | A |
+| Select (Right Shift) | — | Return to the ZIP menu / exit |
+
+### Return and Exit Behavior
+
+RetroPad **Select** is the core's back action. When a `.zip` package has
+launched one of its games, pressing Select returns to the package's `FHUI.smf`
+menu. Pressing Select from that menu, or while running a directly loaded
+`.smf`, `.sgm`, or `.ssl` file, asks the frontend to close the core.
+
+Select is handled on the initial press only and is not sent to Native32 game
+input. If Select is also configured as a RetroArch hotkey, remap either the
+core action or the conflicting frontend hotkey.
 
 ## Core Options
 

--- a/docs/Standalone-Emulator.md
+++ b/docs/Standalone-Emulator.md
@@ -34,7 +34,8 @@ native32-emu path/to/game.zip
 When loading from a `.zip` file, the emulator starts the FHUI menu. Selecting a
 game launches it; pressing **ESC** during gameplay returns to the menu. Pressing
 **ESC** on the menu itself exits the emulator. When loading a `.smf` file
-directly, **ESC** exits as usual.
+directly, **ESC** exits as usual. This matches the RetroArch core's back-action
+behavior, where RetroPad **Select** performs the same return-or-exit operation.
 
 You can always print the built-in help with:
 


### PR DESCRIPTION
## Summary

Closes #96.

Add a consistent back action across the standalone emulator and the libretro
core. RetroPad Select now returns a ZIP-loaded child game to its FHUI menu and
requests frontend shutdown when no menu is available.

## Problem

The standalone emulator already used Escape to return from a game in a ZIP
package to the FHUI menu, but the libretro core had no equivalent action.
RetroArch owns Escape as a frontend hotkey, so users on keyboard-free devices
had to quit RetroArch completely to switch games within a ZIP package.

## Solution

Move the shared return-to-menu operation into `Emulator` and invoke it from
both frontends. The standalone frontend keeps Escape as its trigger, while the
libretro core registers RetroPad Select as `Return / Exit`. Select is handled
on its rising edge and is not forwarded as a Native32 game button. If there is
no ZIP menu to return to, the core uses `RETRO_ENVIRONMENT_SHUTDOWN` to ask the
frontend to close it.

## Changes

- `crates/native32emu-core/src/emulator.rs` — add the shared return-to-menu operation.
- `crates/native32emu/src/main.rs` — route the standalone Escape action through the shared operation.
- `crates/native32emu-libretro/src/libretro/api.rs` — register and handle RetroPad Select, including press-edge detection and frontend shutdown.
- `crates/native32emu-core/tests/smoke.rs` — add a ZIP return-to-menu regression test using local game assets.
- `README.md`, `docs/RetroArch-Core.md`, `docs/Standalone-Emulator.md` — document the unified return and exit behavior.

## Verification

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `cargo build --workspace --release` ✓
- `cargo test --workspace` ✓
- `cargo test -p native32emu-core --test smoke back_action_returns_to_zip_menu -- --ignored --nocapture` ✓
- CI: pending

## Notes for reviewer

- The ZIP regression test passed with the local `native32_game.zip` package.
- RetroArch frontend hotkeys that also use Select may require an input remap.
