### PR TITLE
fix: return to parent SMF applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ and all command-line options.
 
 Install **Native32 (Native32Emu)** from RetroArch's Core Downloader, or install
 the release files manually, then load a supported game through **Load Content**.
-Press RetroPad **Select** to return from a ZIP-loaded game to its package menu;
-press it again on that menu, or while running a directly loaded file, to close
-the core.
+Press RetroPad **Select** to return from a child game to the SMF that launched
+it. Press it with no parent SMF to close the core. This works for directly
+loaded menus as well as ZIP packages.
 
 See the [RetroArch Core](docs/RetroArch-Core.md) guide for installation,
 supported platforms and features, RetroPad mapping, core options, and cheats.

--- a/crates/native32emu-core/src/content_loader.rs
+++ b/crates/native32emu-core/src/content_loader.rs
@@ -1,10 +1,19 @@
-// Content loader: handles SSL multi-file content loading and switching.
+// Content loader: handles typed content loading and switching.
 
 use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ContentLoadKind {
+    #[default]
+    Replace,
+    LaunchChild,
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ContentLoader {
     pub pending_content: Option<String>,
+    #[serde(default)]
+    pub pending_kind: ContentLoadKind,
 }
 
 impl Default for ContentLoader {
@@ -17,11 +26,21 @@ impl ContentLoader {
     pub fn new() -> Self {
         Self {
             pending_content: None,
+            pending_kind: ContentLoadKind::Replace,
         }
     }
 
     /// Mark content for loading at the end of the current tick.
     pub fn queue_load(&mut self, filename: &str) {
+        self.queue(filename, ContentLoadKind::Replace);
+    }
+
+    /// Mark a child application for loading at the end of the current tick.
+    pub fn queue_child(&mut self, filename: &str) {
+        self.queue(filename, ContentLoadKind::LaunchChild);
+    }
+
+    fn queue(&mut self, filename: &str, kind: ContentLoadKind) {
         // Parse the filename: split by '/', trim each component, remove empty segments.
         // Native32 games often pad directory names with trailing spaces (e.g. "BBLADE  ").
         let parts: Vec<&str> = filename
@@ -34,6 +53,7 @@ impl ContentLoader {
             return;
         }
         self.pending_content = Some(parts.join("/"));
+        self.pending_kind = kind;
     }
 
     /// Check if there's pending content to load.
@@ -42,8 +62,10 @@ impl ContentLoader {
     }
 
     /// Take the pending content filename.
-    pub fn take_pending(&mut self) -> Option<String> {
-        self.pending_content.take()
+    pub fn take_pending(&mut self) -> Option<(String, ContentLoadKind)> {
+        let content = self.pending_content.take()?;
+        let kind = std::mem::take(&mut self.pending_kind);
+        Some((content, kind))
     }
 
     /// Find the content file by searching up the directory tree.
@@ -130,28 +152,40 @@ mod tests {
         let mut loader = ContentLoader::new();
         loader.queue_load("level1.ssl");
         assert!(loader.has_pending());
-        assert_eq!(loader.take_pending(), Some("level1.ssl".to_string()));
+        assert_eq!(
+            loader.take_pending(),
+            Some(("level1.ssl".to_string(), ContentLoadKind::Replace))
+        );
     }
 
     #[test]
     fn test_queue_load_trims_trailing_spaces() {
         let mut loader = ContentLoader::new();
         loader.queue_load("BBLADE  /level1.ssl");
-        assert_eq!(loader.take_pending(), Some("BBLADE/level1.ssl".to_string()));
+        assert_eq!(
+            loader.take_pending(),
+            Some(("BBLADE/level1.ssl".to_string(), ContentLoadKind::Replace))
+        );
     }
 
     #[test]
     fn test_queue_load_trims_leading_spaces() {
         let mut loader = ContentLoader::new();
         loader.queue_load("  BBLADE/level1.ssl");
-        assert_eq!(loader.take_pending(), Some("BBLADE/level1.ssl".to_string()));
+        assert_eq!(
+            loader.take_pending(),
+            Some(("BBLADE/level1.ssl".to_string(), ContentLoadKind::Replace))
+        );
     }
 
     #[test]
     fn test_queue_load_removes_empty_segments() {
         let mut loader = ContentLoader::new();
         loader.queue_load("///BBLADE///level1.ssl///");
-        assert_eq!(loader.take_pending(), Some("BBLADE/level1.ssl".to_string()));
+        assert_eq!(
+            loader.take_pending(),
+            Some(("BBLADE/level1.ssl".to_string(), ContentLoadKind::Replace))
+        );
     }
 
     #[test]
@@ -184,7 +218,10 @@ mod tests {
         loader.queue_load("  Game Dir  /  Sub Dir  /  file.ssl  ");
         assert_eq!(
             loader.take_pending(),
-            Some("Game Dir/Sub Dir/file.ssl".to_string())
+            Some((
+                "Game Dir/Sub Dir/file.ssl".to_string(),
+                ContentLoadKind::Replace
+            ))
         );
     }
 
@@ -202,7 +239,41 @@ mod tests {
         let mut loader = ContentLoader::new();
         loader.queue_load("first.ssl");
         loader.queue_load("second.ssl");
-        assert_eq!(loader.take_pending(), Some("second.ssl".to_string()));
+        assert_eq!(
+            loader.take_pending(),
+            Some(("second.ssl".to_string(), ContentLoadKind::Replace))
+        );
+    }
+
+    #[test]
+    fn test_queue_child_marks_launch_kind() {
+        let mut loader = ContentLoader::new();
+        loader.queue_child("child.smf");
+        assert_eq!(
+            loader.take_pending(),
+            Some(("child.smf".to_string(), ContentLoadKind::LaunchChild))
+        );
+    }
+
+    #[test]
+    fn test_replacement_overwrites_child_kind() {
+        let mut loader = ContentLoader::new();
+        loader.queue_child("child.smf");
+        loader.queue_load("scene.ssl");
+        assert_eq!(
+            loader.take_pending(),
+            Some(("scene.ssl".to_string(), ContentLoadKind::Replace))
+        );
+    }
+
+    #[test]
+    fn test_old_serialized_loader_defaults_to_replacement() {
+        let mut loader: ContentLoader =
+            serde_json::from_str(r#"{"pending_content":"scene.ssl"}"#).unwrap();
+        assert_eq!(
+            loader.take_pending(),
+            Some(("scene.ssl".to_string(), ContentLoadKind::Replace))
+        );
     }
 
     #[test]

--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -3,7 +3,7 @@
 use crate::action_vm::{ActionProp, ActionVM, VmHost};
 use crate::audio_engine::AudioEngine;
 use crate::cheats::CheatManager;
-use crate::content_loader::ContentLoader;
+use crate::content_loader::{ContentLoadKind, ContentLoader};
 use crate::file_loader::{FrameObject, Native32Reader, ObjectType};
 use crate::frame_player::FramePlayer;
 use crate::input_handler::InputHandler;
@@ -20,6 +20,12 @@ fn timeline_sound_value(index: u16, loop_count: i16) -> u16 {
         loop_count.clamp(0, 0xFE) as u16
     };
     (repeat << 8) | (index & 0xFF)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ReturnFrame {
+    path: PathBuf,
+    menu_context: Option<String>,
 }
 
 /// The platform-independent emulator core.
@@ -56,10 +62,8 @@ pub struct Emulator {
     /// Active cutscene player, if a video is currently playing.
     pub video_player: Option<crate::mpeg::VideoPlayer>,
     active_video_name: Option<String>,
-    /// The initial menu file loaded at startup from a ZIP package.
-    /// Set to None when the user loaded a game directly (not from a menu).
-    /// Used to support the frontends' shared back action.
-    pub initial_file: Option<PathBuf>,
+    /// Parent SMF applications that can be restored by the shared back action.
+    return_stack: Vec<ReturnFrame>,
     /// When true, cutscene videos are skipped automatically as soon as they
     /// become active, instead of waiting for the user to press A/B.
     pub auto_skip_cutscenes: bool,
@@ -94,14 +98,6 @@ impl Emulator {
 
         let save_manager = SaveManager::new(&game_path);
 
-        // When loaded from a ZIP, remember the menu path so the frontend's
-        // back action can return to the menu instead of exiting.
-        let initial_file = if is_zip {
-            Some(game_path.clone())
-        } else {
-            None
-        };
-
         let content_root = game_path
             .parent()
             .unwrap_or_else(|| Path::new(""))
@@ -128,7 +124,7 @@ impl Emulator {
             pending_videos: Vec::new(),
             video_player: None,
             active_video_name: None,
-            initial_file,
+            return_stack: Vec::new(),
             auto_skip_cutscenes: false,
             _temp_dir,
         })
@@ -147,37 +143,38 @@ impl Emulator {
         }
     }
 
-    /// Whether the emulator can return to its initial ZIP menu.
-    /// Returns true only when an initial menu file was set (ZIP mode) and the
-    /// current file is different (i.e. we are in a game, not already on the menu).
-    pub fn can_return_to_menu(&self) -> bool {
-        self.initial_file
-            .as_ref()
-            .is_some_and(|p| *p != self.filename)
+    /// Whether the emulator can return to a parent SMF application.
+    pub fn can_return_to_parent(&self) -> bool {
+        !self.return_stack.is_empty()
     }
 
-    /// Return to the initial ZIP menu when one is available.
+    /// Return to the SMF application that launched the current child.
     ///
-    /// Returns `true` after reloading the menu and `false` when the frontend
+    /// Returns `true` after reloading the parent and `false` when the frontend
     /// should handle the back action by ending the current emulation session.
-    pub fn try_return_to_menu(&mut self) -> Result<bool> {
-        if !self.can_return_to_menu() {
+    pub fn try_return_to_parent(&mut self) -> Result<bool> {
+        let Some(frame) = self.return_stack.last().cloned() else {
             return Ok(false);
-        }
+        };
 
-        let menu_path = self
-            .initial_file
-            .clone()
-            .expect("a returnable menu must have an initial file");
-        self.reload_from_path(menu_path)?;
+        self.load_path(frame.path, frame.menu_context)?;
+        self.return_stack.pop();
         Ok(true)
     }
 
     /// Reload the emulator from the given file path, performing a full state
-    /// reset. Preserves `initial_file` so the user can return to the menu again.
+    /// reset and starting a new navigation session.
     pub fn reload_from_path(&mut self, path: PathBuf) -> Result<()> {
+        self.load_path(path, None)?;
+        self.return_stack.clear();
+        Ok(())
+    }
+
+    fn load_path(&mut self, path: PathBuf, menu_context: Option<String>) -> Result<()> {
         let data = std::fs::read(&path)
             .with_context(|| format!("Failed to read game file: {}", path.display()))?;
+        let mut reader = Native32Reader::new(data);
+        reader.init()?;
 
         self.audio.stop_all();
         self.renderer.clear_sprite_overrides();
@@ -191,10 +188,9 @@ impl Emulator {
         self.vm = ActionVM::new();
         self.content_loader = ContentLoader::new();
         self.cur_frame_objects.clear();
-        self.menu_context = None;
+        self.menu_context = menu_context;
         self.filename = path;
-        self.reader = Native32Reader::new(data);
-        self.reader.init()?;
+        self.reader = reader;
         self.audio = AudioEngine::new(self.reader.colorspace, (self.audio.volume * 100.0) as u32);
         self.save_manager = SaveManager::new(&self.filename);
 
@@ -367,10 +363,10 @@ impl Emulator {
 
         self.handle_buttons();
 
-        // Handle content switching (SSL_PlayNext)
+        // Handle queued content switching.
         if self.content_loader.has_pending() && !self.is_cutscene_active() {
-            if let Some(filename) = self.content_loader.take_pending() {
-                if let Err(e) = self.switch_content(&filename) {
+            if let Some((filename, kind)) = self.content_loader.take_pending() {
+                if let Err(e) = self.switch_content(&filename, kind) {
                     log::error!("Failed to switch content: {}", e);
                 }
             }
@@ -598,12 +594,35 @@ impl Emulator {
         }
     }
 
-    /// Switch to a new content file (for SSL_PlayNext).
-    fn switch_content(&mut self, filename: &str) -> anyhow::Result<()> {
+    /// Switch to a new content file.
+    fn switch_content(&mut self, filename: &str, kind: ContentLoadKind) -> anyhow::Result<()> {
         let fullpath = ContentLoader::find_content_file(&self.filename, filename)
             .ok_or_else(|| anyhow::anyhow!("Content file not found: {}", filename))?;
 
         log::info!("Loading content: {}", fullpath.display());
+
+        // Validate the new content before changing the running application.
+        let data = std::fs::read(&fullpath)
+            .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", fullpath.display(), e))?;
+        let mut reader = Native32Reader::new(data);
+        reader.init()?;
+
+        let new_content_root = if fullpath.starts_with(&self.content_root) {
+            self.content_root.clone()
+        } else {
+            self.content_root
+                .ancestors()
+                .find(|ancestor| fullpath.starts_with(ancestor))
+                .context("switched content has no common root with the initial content")?
+                .to_path_buf()
+        };
+        let replace_save_manager =
+            !has_extension(&self.filename, "ssl") || !has_extension(&fullpath, "ssl");
+        let return_frame =
+            should_push_return_frame(kind, &self.filename, &fullpath).then(|| ReturnFrame {
+                path: self.filename.clone(),
+                menu_context: self.menu_context.clone(),
+            });
 
         // Stop all sounds
         self.audio.stop_all();
@@ -619,29 +638,17 @@ impl Emulator {
         self.vm = ActionVM::new();
         self.content_loader = ContentLoader::new();
 
-        // Load new file
-        let data = std::fs::read(&fullpath)
-            .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", fullpath.display(), e))?;
-        let is_ssl = |path: &Path| {
-            path.extension()
-                .and_then(|extension| extension.to_str())
-                .is_some_and(|extension| extension.eq_ignore_ascii_case("ssl"))
-        };
         // Consecutive SSL scenes belong to one game and share its save data.
-        if !is_ssl(&self.filename) || !is_ssl(&fullpath) {
+        if replace_save_manager {
             self.save_manager = SaveManager::new(&fullpath);
         }
-        if !fullpath.starts_with(&self.content_root) {
-            self.content_root = self
-                .content_root
-                .ancestors()
-                .find(|ancestor| fullpath.starts_with(ancestor))
-                .context("switched content has no common root with the initial content")?
-                .to_path_buf();
+        self.content_root = new_content_root;
+        if let Some(frame) = return_frame {
+            self.return_stack.push(frame);
+            self.menu_context = None;
         }
         self.filename = fullpath;
-        self.reader = Native32Reader::new(data);
-        self.reader.init()?;
+        self.reader = reader;
         self.audio = AudioEngine::new(self.reader.colorspace, (self.audio.volume * 100.0) as u32);
         self.cur_frame_objects.clear();
 
@@ -678,22 +685,24 @@ impl Emulator {
 
     /// Serialize the emulator state to a buffer.
     pub fn serialize(&self, buffer: &mut [u8]) -> Result<()> {
-        use crate::save_state::{EmulatorState, VideoState};
+        use crate::save_state::{EmulatorState, ReturnFrameState, VideoState};
 
-        let relative = self
-            .filename
-            .strip_prefix(&self.content_root)
-            .context("current content is outside the save-state content root")?;
-        if relative
-            .components()
-            .any(|component| !matches!(component, Component::Normal(_)))
-        {
-            anyhow::bail!("current content path cannot be represented safely");
-        }
-        let content_path = relative
-            .to_str()
-            .context("current content path is not valid UTF-8")?
-            .replace('\\', "/");
+        let content_path =
+            portable_content_path(&self.filename, &self.content_root, "current content")?;
+        let return_stack = self
+            .return_stack
+            .iter()
+            .map(|frame| {
+                Ok(ReturnFrameState {
+                    content_path: portable_content_path(
+                        &frame.path,
+                        &self.content_root,
+                        "return target",
+                    )?,
+                    menu_context: frame.menu_context.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         let state = EmulatorState {
             content_path,
@@ -706,6 +715,7 @@ impl Emulator {
             renderer: self.renderer.save_state(),
             content_loader: self.content_loader.clone(),
             menu_context: self.menu_context.clone(),
+            return_stack: Some(return_stack),
             tick_count: self.tick_count,
             time_ms: self.time_ms,
             pending_videos: self.pending_videos.clone(),
@@ -724,16 +734,42 @@ impl Emulator {
     /// Deserialize the emulator state from a buffer.
     pub fn deserialize(&mut self, buffer: &[u8]) -> Result<()> {
         let state = crate::save_state::decode(buffer)?;
-        let relative = Path::new(&state.content_path);
-        if relative.as_os_str().is_empty()
-            || relative
-                .components()
-                .any(|component| !matches!(component, Component::Normal(_)))
-        {
-            anyhow::bail!("save state contains an unsafe content path");
-        }
-
-        let content_path = self.content_root.join(relative);
+        let content_path =
+            resolve_state_content_path(&self.content_root, &state.content_path, "current content")?;
+        let (return_stack, menu_context) = if let Some(saved_stack) = &state.return_stack {
+            let stack = saved_stack
+                .iter()
+                .map(|frame| {
+                    let path = resolve_state_content_path(
+                        &self.content_root,
+                        &frame.content_path,
+                        "return target",
+                    )?;
+                    if !has_extension(&path, "smf") {
+                        anyhow::bail!("save-state return target is not an SMF file");
+                    }
+                    Ok(ReturnFrame {
+                        path,
+                        menu_context: frame.menu_context.clone(),
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            (stack, state.menu_context.clone())
+        } else if !self.return_stack.is_empty() {
+            // Loading an old state during an active session keeps its known parents.
+            (self.return_stack.clone(), state.menu_context.clone())
+        } else if self._temp_dir.is_some() && self.filename != content_path {
+            // Old ZIP save states relied on the package entry point implicitly.
+            (
+                vec![ReturnFrame {
+                    path: self.filename.clone(),
+                    menu_context: state.menu_context.clone(),
+                }],
+                None,
+            )
+        } else {
+            (Vec::new(), state.menu_context.clone())
+        };
         let data = std::fs::read(&content_path).with_context(|| {
             format!(
                 "failed to read save-state content: {}",
@@ -765,7 +801,8 @@ impl Emulator {
         self.vm.vars = state.vm_vars;
         self.vm.rng_state = state.rng_state;
         self.content_loader = state.content_loader;
-        self.menu_context = state.menu_context;
+        self.menu_context = menu_context;
+        self.return_stack = return_stack;
         self.tick_count = state.tick_count;
         self.time_ms = state.time_ms;
         self.pending_videos = state.pending_videos;
@@ -989,7 +1026,7 @@ impl VmHost for Emulator {
                 // `url` is a root-relative game path without extension
                 // (e.g. "/EACT    /EBBLADE"); load the matching .smf game.
                 log::info!("StartGame({})", url);
-                self.content_loader.queue_load(&format!("{}.smf", url));
+                self.content_loader.queue_child(&format!("{}.smf", url));
             }
             "LoadImage" => {
                 // url = "<spriteName>+D+<picPath>" : load the thumbnail stored
@@ -1140,6 +1177,35 @@ fn fhui_str_sub(parts: &[&str]) -> String {
         .unwrap_or_default()
 }
 
+fn portable_content_path(path: &Path, root: &Path, label: &str) -> Result<String> {
+    let relative = path
+        .strip_prefix(root)
+        .with_context(|| format!("{label} is outside the save-state content root"))?;
+    if relative.as_os_str().is_empty()
+        || relative
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        anyhow::bail!("{label} path cannot be represented safely");
+    }
+    Ok(relative
+        .to_str()
+        .with_context(|| format!("{label} path is not valid UTF-8"))?
+        .replace('\\', "/"))
+}
+
+fn resolve_state_content_path(root: &Path, value: &str, label: &str) -> Result<PathBuf> {
+    let relative = Path::new(value);
+    if relative.as_os_str().is_empty()
+        || relative
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        anyhow::bail!("save state contains an unsafe {label} path");
+    }
+    Ok(root.join(relative))
+}
+
 /// Normalize a Native32 content path: split on '/', trim each component
 /// (games pad directory names with trailing spaces), drop empties, rejoin.
 fn normalize_content_path(filename: &str) -> String {
@@ -1149,6 +1215,19 @@ fn normalize_content_path(filename: &str) -> String {
         .filter(|s| !s.is_empty())
         .collect::<Vec<_>>()
         .join("/")
+}
+
+fn has_extension(path: &Path, expected: &str) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case(expected))
+}
+
+fn should_push_return_frame(kind: ContentLoadKind, current: &Path, target: &Path) -> bool {
+    kind == ContentLoadKind::LaunchChild
+        && current != target
+        && has_extension(current, "smf")
+        && has_extension(target, "smf")
 }
 
 /// Check if a file is a ZIP archive by reading its magic bytes.
@@ -1171,4 +1250,37 @@ fn is_zip_file(path: &PathBuf) -> bool {
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn child_smf_launch_creates_return_frame() {
+        assert!(should_push_return_frame(
+            ContentLoadKind::LaunchChild,
+            Path::new("menu.SMF"),
+            Path::new("games/child.smf")
+        ));
+    }
+
+    #[test]
+    fn replacement_and_ssl_transitions_do_not_create_return_frames() {
+        assert!(!should_push_return_frame(
+            ContentLoadKind::Replace,
+            Path::new("menu.smf"),
+            Path::new("child.smf")
+        ));
+        assert!(!should_push_return_frame(
+            ContentLoadKind::LaunchChild,
+            Path::new("menu.smf"),
+            Path::new("scene.ssl")
+        ));
+        assert!(!should_push_return_frame(
+            ContentLoadKind::LaunchChild,
+            Path::new("menu.smf"),
+            Path::new("menu.smf")
+        ));
+    }
 }

--- a/crates/native32emu-core/src/emulator.rs
+++ b/crates/native32emu-core/src/emulator.rs
@@ -25,7 +25,6 @@ fn timeline_sound_value(index: u16, loop_count: i16) -> u16 {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ReturnFrame {
     path: PathBuf,
-    menu_context: Option<String>,
 }
 
 /// The platform-independent emulator core.
@@ -157,7 +156,7 @@ impl Emulator {
             return Ok(false);
         };
 
-        self.load_path(frame.path, frame.menu_context)?;
+        self.load_path(frame.path)?;
         self.return_stack.pop();
         Ok(true)
     }
@@ -165,12 +164,12 @@ impl Emulator {
     /// Reload the emulator from the given file path, performing a full state
     /// reset and starting a new navigation session.
     pub fn reload_from_path(&mut self, path: PathBuf) -> Result<()> {
-        self.load_path(path, None)?;
+        self.load_path(path)?;
         self.return_stack.clear();
         Ok(())
     }
 
-    fn load_path(&mut self, path: PathBuf, menu_context: Option<String>) -> Result<()> {
+    fn load_path(&mut self, path: PathBuf) -> Result<()> {
         let data = std::fs::read(&path)
             .with_context(|| format!("Failed to read game file: {}", path.display()))?;
         let mut reader = Native32Reader::new(data);
@@ -188,7 +187,7 @@ impl Emulator {
         self.vm = ActionVM::new();
         self.content_loader = ContentLoader::new();
         self.cur_frame_objects.clear();
-        self.menu_context = menu_context;
+        self.menu_context = None;
         self.filename = path;
         self.reader = reader;
         self.audio = AudioEngine::new(self.reader.colorspace, (self.audio.volume * 100.0) as u32);
@@ -621,7 +620,6 @@ impl Emulator {
         let return_frame =
             should_push_return_frame(kind, &self.filename, &fullpath).then(|| ReturnFrame {
                 path: self.filename.clone(),
-                menu_context: self.menu_context.clone(),
             });
 
         // Stop all sounds
@@ -699,7 +697,6 @@ impl Emulator {
                         &self.content_root,
                         "return target",
                     )?,
-                    menu_context: frame.menu_context.clone(),
                 })
             })
             .collect::<Result<Vec<_>>>()?;
@@ -736,8 +733,8 @@ impl Emulator {
         let state = crate::save_state::decode(buffer)?;
         let content_path =
             resolve_state_content_path(&self.content_root, &state.content_path, "current content")?;
-        let (return_stack, menu_context) = if let Some(saved_stack) = &state.return_stack {
-            let stack = saved_stack
+        let return_stack = if let Some(saved_stack) = &state.return_stack {
+            saved_stack
                 .iter()
                 .map(|frame| {
                     let path = resolve_state_content_path(
@@ -748,27 +745,19 @@ impl Emulator {
                     if !has_extension(&path, "smf") {
                         anyhow::bail!("save-state return target is not an SMF file");
                     }
-                    Ok(ReturnFrame {
-                        path,
-                        menu_context: frame.menu_context.clone(),
-                    })
+                    Ok(ReturnFrame { path })
                 })
-                .collect::<Result<Vec<_>>>()?;
-            (stack, state.menu_context.clone())
+                .collect::<Result<Vec<_>>>()?
         } else if !self.return_stack.is_empty() {
             // Loading an old state during an active session keeps its known parents.
-            (self.return_stack.clone(), state.menu_context.clone())
+            self.return_stack.clone()
         } else if self._temp_dir.is_some() && self.filename != content_path {
             // Old ZIP save states relied on the package entry point implicitly.
-            (
-                vec![ReturnFrame {
-                    path: self.filename.clone(),
-                    menu_context: state.menu_context.clone(),
-                }],
-                None,
-            )
+            vec![ReturnFrame {
+                path: self.filename.clone(),
+            }]
         } else {
-            (Vec::new(), state.menu_context.clone())
+            Vec::new()
         };
         let data = std::fs::read(&content_path).with_context(|| {
             format!(
@@ -801,7 +790,7 @@ impl Emulator {
         self.vm.vars = state.vm_vars;
         self.vm.rng_state = state.rng_state;
         self.content_loader = state.content_loader;
-        self.menu_context = menu_context;
+        self.menu_context = state.menu_context;
         self.return_stack = return_stack;
         self.tick_count = state.tick_count;
         self.time_ms = state.time_ms;

--- a/crates/native32emu-core/src/save_state.rs
+++ b/crates/native32emu-core/src/save_state.rs
@@ -24,7 +24,6 @@ pub(crate) struct VideoState {
 #[derive(Serialize, Deserialize)]
 pub(crate) struct ReturnFrameState {
     pub content_path: String,
-    pub menu_context: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/crates/native32emu-core/src/save_state.rs
+++ b/crates/native32emu-core/src/save_state.rs
@@ -22,6 +22,12 @@ pub(crate) struct VideoState {
 }
 
 #[derive(Serialize, Deserialize)]
+pub(crate) struct ReturnFrameState {
+    pub content_path: String,
+    pub menu_context: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
 pub(crate) struct EmulatorState {
     pub content_path: String,
     pub content_crc32: u32,
@@ -33,6 +39,9 @@ pub(crate) struct EmulatorState {
     pub renderer: RendererState,
     pub content_loader: ContentLoader,
     pub menu_context: Option<String>,
+    /// None identifies states written before parent-SMF navigation was added.
+    #[serde(default)]
+    pub return_stack: Option<Vec<ReturnFrameState>>,
     pub tick_count: u64,
     pub time_ms: u32,
     pub pending_videos: Vec<String>,

--- a/crates/native32emu-core/tests/smoke.rs
+++ b/crates/native32emu-core/tests/smoke.rs
@@ -340,6 +340,7 @@ fn nav_select_na32_loads_native32_menu() {
         final_name.eq_ignore_ascii_case("NA32UI.smf"),
         "Native32 selection loaded {final_name} instead of NA32UI.smf"
     );
+    assert!(!emu.can_return_to_parent());
 }
 
 #[test]
@@ -505,7 +506,7 @@ fn fhui_menu_starts_selected_game() {
 
     // Tap confirm to enter the category, then confirm again to launch the
     // first game.
-    let emu = run_scripted(&menu, 260, |frame| {
+    let mut emu = run_scripted(&menu, 260, |frame| {
         if (50..53).contains(&frame) || (110..113).contains(&frame) {
             vec![KEY_Z]
         } else {
@@ -524,6 +525,11 @@ fn fhui_menu_starts_selected_game() {
         !name.eq_ignore_ascii_case("FHUI.smf"),
         "selecting a game did not launch it: still on the menu"
     );
+    assert!(emu.can_return_to_parent());
+    assert!(emu
+        .try_return_to_parent()
+        .expect("return to FHUI after selected game"));
+    assert_eq!(emu.filename, menu);
 }
 
 /// Regression test for Magical Adventure's first mini-game flow: a confirm
@@ -796,8 +802,8 @@ fn zip_file_loads_fhui() {
     );
 }
 
-/// A ZIP with NA32UI.smf as its only menu entry point should boot it and use it
-/// as the back-action target.
+/// A ZIP with NA32UI.smf as its only menu entry point should boot it and allow
+/// a child launch to return to it.
 #[test]
 #[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
 fn zip_file_loads_na32ui() {
@@ -840,20 +846,17 @@ fn zip_file_loads_na32ui() {
         .and_then(|name| name.to_str())
         .is_some_and(|name| name.eq_ignore_ascii_case("NA32UI.smf")));
 
-    let child_path = menu_path
-        .parent()
-        .expect("menu path has no parent")
-        .join("GAME.smf");
-    emu.reload_from_path(child_path)
-        .expect("load extracted child game");
-    assert!(emu.try_return_to_menu().expect("return to NA32UI menu"));
+    emu.content_loader.queue_child("GAME.smf");
+    emu.tick();
+    assert!(emu.can_return_to_parent());
+    assert!(emu.try_return_to_parent().expect("return to NA32UI menu"));
     assert_eq!(emu.filename, menu_path);
 }
 
-/// The shared back action should return a ZIP-loaded child game to its menu.
+/// The shared back action should return a child SMF to the SMF that launched it.
 #[test]
 #[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
-fn back_action_returns_to_zip_menu() {
+fn back_action_returns_to_parent_smf() {
     let dir = match game_dir() {
         Some(d) => d,
         None => {
@@ -880,16 +883,122 @@ fn back_action_returns_to_zip_menu() {
     );
     let child_game = games
         .into_iter()
-        .find(|path| *path != menu_path)
-        .expect("ZIP package contains no child game");
+        .find(|path| {
+            *path != menu_path
+                && path
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("smf"))
+        })
+        .expect("ZIP package contains no child SMF");
+    let child_name = child_game
+        .strip_prefix(menu_path.parent().expect("menu path has no parent"))
+        .expect("child SMF is outside the package root")
+        .to_string_lossy()
+        .replace('\\', "/");
 
-    emu.reload_from_path(child_game)
-        .expect("failed to load child game");
-    assert!(emu.try_return_to_menu().expect("back action failed"));
+    emu.content_loader.queue_child(&child_name);
+    emu.tick();
+    assert_eq!(emu.filename, child_game);
+    assert!(emu.try_return_to_parent().expect("back action failed"));
     assert_eq!(emu.filename, menu_path);
     assert!(!emu
-        .try_return_to_menu()
+        .try_return_to_parent()
         .expect("back action at the menu failed"));
+}
+
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn direct_smf_child_launch_restores_parent_context() {
+    let dir = game_dir().expect("no game directory found");
+    let parent = find_asset(&dir, "FHUI.smf").expect("FHUI.smf not found");
+    let mut games = Vec::new();
+    collect_games(&dir, &mut games);
+    let child = games
+        .into_iter()
+        .find(|path| {
+            *path != parent
+                && path
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("smf"))
+        })
+        .expect("no child SMF found");
+    let child_name = child
+        .strip_prefix(parent.parent().expect("parent SMF has no directory"))
+        .expect("child SMF is outside the content root")
+        .to_string_lossy()
+        .replace('\\', "/");
+    let mut emu = Emulator::from_path(parent.clone(), 100).expect("load parent SMF");
+    emu.menu_context = Some("category=2;game=4".to_string());
+
+    emu.content_loader.queue_child(&child_name);
+    emu.tick();
+    assert_eq!(emu.filename, child);
+    assert_eq!(emu.menu_context, None);
+    assert!(emu.try_return_to_parent().expect("return to direct parent"));
+    assert_eq!(emu.filename, parent);
+    assert_eq!(emu.menu_context.as_deref(), Some("category=2;game=4"));
+    assert!(!emu
+        .try_return_to_parent()
+        .expect("back action at the direct parent failed"));
+}
+
+#[test]
+#[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
+fn nested_smf_return_stack_survives_save_state() {
+    let dir = game_dir().expect("no game directory found");
+    let root = find_asset(&dir, "FHUI.smf").expect("FHUI.smf not found");
+    let content_root = root.parent().expect("root SMF has no directory");
+    let mut games = Vec::new();
+    collect_games(&dir, &mut games);
+    let children: Vec<PathBuf> = games
+        .into_iter()
+        .filter(|path| {
+            *path != root
+                && path
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("smf"))
+        })
+        .take(2)
+        .collect();
+    assert_eq!(children.len(), 2, "need two child SMFs for nested test");
+    let relative_name = |path: &Path| {
+        path.strip_prefix(content_root)
+            .expect("child SMF is outside the content root")
+            .to_string_lossy()
+            .replace('\\', "/")
+    };
+
+    let mut emu = Emulator::from_path(root.clone(), 100).expect("load root SMF");
+    emu.menu_context = Some("root-context".to_string());
+    emu.content_loader.queue_child(&relative_name(&children[0]));
+    emu.tick();
+    emu.menu_context = Some("child-context".to_string());
+    emu.frame_player.take_next_frame();
+    emu.frame_player.playing = false;
+    emu.content_loader.queue_child(&relative_name(&children[1]));
+    emu.tick();
+
+    let mut state = vec![0; emu.serialize_size()];
+    emu.serialize(&mut state)
+        .expect("serialize nested return stack");
+    emu.reload_from_path(root.clone())
+        .expect("reset navigation session");
+    assert!(!emu.can_return_to_parent());
+    emu.deserialize(&state)
+        .expect("restore nested return stack");
+
+    assert!(emu.try_return_to_parent().expect("return to child SMF"));
+    assert_eq!(emu.filename, children[0]);
+    assert_eq!(emu.menu_context.as_deref(), Some("child-context"));
+    assert!(emu.try_return_to_parent().expect("return to root SMF"));
+    assert_eq!(emu.filename, root);
+    assert_eq!(emu.menu_context.as_deref(), Some("root-context"));
+    assert!(!emu
+        .try_return_to_parent()
+        .expect("back action at root failed"));
 }
 
 /// A placed Pirate bomb must start at the template's first visible frame.

--- a/crates/native32emu-core/tests/smoke.rs
+++ b/crates/native32emu-core/tests/smoke.rs
@@ -909,7 +909,7 @@ fn back_action_returns_to_parent_smf() {
 
 #[test]
 #[ignore = "requires local Native32 game assets (set NATIVE32_GAME_DIR)"]
-fn direct_smf_child_launch_restores_parent_context() {
+fn direct_smf_child_launch_reloads_parent() {
     let dir = game_dir().expect("no game directory found");
     let parent = find_asset(&dir, "FHUI.smf").expect("FHUI.smf not found");
     let mut games = Vec::new();
@@ -938,7 +938,7 @@ fn direct_smf_child_launch_restores_parent_context() {
     assert_eq!(emu.menu_context, None);
     assert!(emu.try_return_to_parent().expect("return to direct parent"));
     assert_eq!(emu.filename, parent);
-    assert_eq!(emu.menu_context.as_deref(), Some("category=2;game=4"));
+    assert_eq!(emu.menu_context, None);
     assert!(!emu
         .try_return_to_parent()
         .expect("back action at the direct parent failed"));
@@ -972,10 +972,8 @@ fn nested_smf_return_stack_survives_save_state() {
     };
 
     let mut emu = Emulator::from_path(root.clone(), 100).expect("load root SMF");
-    emu.menu_context = Some("root-context".to_string());
     emu.content_loader.queue_child(&relative_name(&children[0]));
     emu.tick();
-    emu.menu_context = Some("child-context".to_string());
     emu.frame_player.take_next_frame();
     emu.frame_player.playing = false;
     emu.content_loader.queue_child(&relative_name(&children[1]));
@@ -992,13 +990,49 @@ fn nested_smf_return_stack_survives_save_state() {
 
     assert!(emu.try_return_to_parent().expect("return to child SMF"));
     assert_eq!(emu.filename, children[0]);
-    assert_eq!(emu.menu_context.as_deref(), Some("child-context"));
     assert!(emu.try_return_to_parent().expect("return to root SMF"));
     assert_eq!(emu.filename, root);
-    assert_eq!(emu.menu_context.as_deref(), Some("root-context"));
     assert!(!emu
         .try_return_to_parent()
         .expect("back action at root failed"));
+}
+
+#[test]
+#[ignore = "requires packed local Native32 assets (set NATIVE32_PACKED_GAME_DIR)"]
+fn na32ui_return_rebuilds_game_list() {
+    let dir = packed_game_dir().expect("no packed game directory found");
+    let menu = find_asset(&dir, "NA32UI.smf").expect("NA32UI.smf not found");
+    let mut emu = run_scripted(&menu, 260, |frame| {
+        if (50..53).contains(&frame) || (110..113).contains(&frame) {
+            vec![KEY_Z]
+        } else {
+            vec![]
+        }
+    })
+    .expect("run NA32UI menu");
+    assert_ne!(emu.filename, menu, "NA32UI did not launch a child SMF");
+    assert!(emu.try_return_to_parent().expect("return to NA32UI"));
+    assert_eq!(emu.menu_context, None);
+
+    for _ in 0..180 {
+        emu.set_buttons(&[]);
+        emu.tick();
+        emu.draw();
+    }
+    for frame in 0..120 {
+        let buttons = if (10..13).contains(&frame) {
+            vec![KEY_Z]
+        } else {
+            vec![]
+        };
+        emu.set_buttons(&buttons);
+        emu.tick();
+        emu.draw();
+    }
+    assert!(
+        emu.renderer.sprite_override_count() > 0,
+        "NA32UI did not rebuild its game-list images"
+    );
 }
 
 /// A placed Pirate bomb must start at the template's first visible frame.

--- a/crates/native32emu-libretro/src/libretro/api.rs
+++ b/crates/native32emu-libretro/src/libretro/api.rs
@@ -233,15 +233,15 @@ pub extern "C" fn retro_run() {
 
         // 2. Handle the frontend-level back action on the Select press edge.
         if return_button_just_pressed(0) {
-            match emu.try_return_to_menu() {
-                Ok(true) => log::info!("Returned to the ZIP game menu"),
+            match emu.try_return_to_parent() {
+                Ok(true) => log::info!("Returned to the parent SMF"),
                 Ok(false) => {
                     log::info!("Requesting frontend shutdown");
                     callbacks::environment(RETRO_ENVIRONMENT_SHUTDOWN, ptr::null_mut());
                     return;
                 }
                 Err(e) => {
-                    log::error!("Failed to reload the ZIP game menu: {}", e);
+                    log::error!("Failed to reload the parent SMF: {}", e);
                     callbacks::environment(RETRO_ENVIRONMENT_SHUTDOWN, ptr::null_mut());
                     return;
                 }

--- a/crates/native32emu/src/main.rs
+++ b/crates/native32emu/src/main.rs
@@ -190,23 +190,23 @@ fn main() -> Result<()> {
     // Main emulation loop
     let mut frame_count: u32 = 0;
     let screenshot_path = cli.screenshot.clone();
-    // Debounce counter: after returning to menu via ESC, suppress further ESC
+    // Debounce counter: after returning to a parent via ESC, suppress further ESC
     // detections for a few frames so the key release is not re-triggered.
     let mut esc_cooldown: u32 = 0;
 
     while window.is_open() {
-        // Handle ESC key: return to menu (ZIP mode) or exit.
+        // Handle ESC key: return to a parent SMF or exit.
         if esc_cooldown > 0 {
             esc_cooldown -= 1;
         } else if window.is_key_down(minifb::Key::Escape) {
-            match emu.try_return_to_menu() {
+            match emu.try_return_to_parent() {
                 Ok(true) => {
                     esc_cooldown = 15; // ~0.5s at 30fps, enough for key release
                     continue;
                 }
                 Ok(false) => break,
                 Err(e) => {
-                    log::error!("Failed to reload menu: {}", e);
+                    log::error!("Failed to reload parent SMF: {}", e);
                     break;
                 }
             }

--- a/docs/RetroArch-Core.md
+++ b/docs/RetroArch-Core.md
@@ -54,15 +54,22 @@ platform-specific installation requirements:
 | D-Pad Down | `0x1e00` | Down |
 | A (SNES East) | `0x8800` | B / Menu |
 | B (SNES South) | `0x4000` | A |
-| Select (Right Shift) | — | Return to the ZIP menu / exit |
+| Select (Right Shift) | — | Return to the parent SMF / exit |
 
 ### Return and Exit Behavior
 
-RetroPad **Select** is the core's back action. When a `.zip` package has
-launched one of its games, pressing Select returns to the package's initial
-`FHUI.smf` or `NA32UI.smf` menu. Pressing Select from that menu, or while
-running a directly loaded `.smf`, `.sgm`, or `.ssl` file, asks the frontend to
-close the core.
+RetroPad **Select** is the core's back action. When one `.smf` application
+launches another through `StartGame`, pressing Select reloads the parent SMF
+and restores its saved menu context. Nested SMF launches can be unwound one
+level at a time. Internal `.ssl` scene transitions do not create extra return
+levels, so Select from any scene in the launched game still returns to its SMF
+launcher.
+
+This behavior is based on the content launch relationship rather than the
+container type or a menu filename. It works for menus loaded directly as well
+as the `FHUI.smf` or `NA32UI.smf` menu selected when opening a ZIP package. If
+the current session has no parent SMF, Select asks the frontend to close the
+core.
 
 Select is handled on the initial press only and is not sent to Native32 game
 input. If Select is also configured as a RetroArch hotkey, remap either the

--- a/docs/RetroArch-Core.md
+++ b/docs/RetroArch-Core.md
@@ -59,11 +59,10 @@ platform-specific installation requirements:
 ### Return and Exit Behavior
 
 RetroPad **Select** is the core's back action. When one `.smf` application
-launches another through `StartGame`, pressing Select reloads the parent SMF
-and restores its saved menu context. Nested SMF launches can be unwound one
-level at a time. Internal `.ssl` scene transitions do not create extra return
-levels, so Select from any scene in the launched game still returns to its SMF
-launcher.
+launches another through `StartGame`, pressing Select reloads the parent SMF as
+a fresh session. Nested SMF launches can be unwound one level at a time.
+Internal `.ssl` scene transitions do not create extra return levels, so Select
+from any scene in the launched game still returns to its SMF launcher.
 
 This behavior is based on the content launch relationship rather than the
 container type or a menu filename. It works for menus loaded directly as well

--- a/docs/Standalone-Emulator.md
+++ b/docs/Standalone-Emulator.md
@@ -32,11 +32,16 @@ native32-emu path/to/game.zip
 ### ZIP Mode
 
 When loading from a `.zip` file, the emulator starts the package's `FHUI.smf`
-or `NA32UI.smf` menu. Selecting a game launches it; pressing **ESC** during
-gameplay returns to the menu. Pressing **ESC** on the menu itself exits the
-emulator. When loading a `.smf` file directly, **ESC** exits as usual. This
-matches the RetroArch core's back-action behavior, where RetroPad **Select**
-performs the same return-or-exit operation.
+or `NA32UI.smf` menu. When that SMF launches a child SMF through `StartGame`,
+pressing **ESC** during gameplay reloads the parent and restores its saved menu
+context. Internal `.ssl` scene changes remain part of the child game and do not
+add return levels. Pressing **ESC** on the initial menu exits the emulator.
+
+The same relationship-based behavior applies outside ZIP mode: a directly
+loaded SMF can launch a child and receive control again, while a directly
+loaded file with no parent exits on **ESC**. Nested SMF launches return one
+level at a time. RetroPad **Select** performs the same return-or-exit operation
+in the RetroArch core.
 
 You can always print the built-in help with:
 

--- a/docs/Standalone-Emulator.md
+++ b/docs/Standalone-Emulator.md
@@ -33,9 +33,9 @@ native32-emu path/to/game.zip
 
 When loading from a `.zip` file, the emulator starts the package's `FHUI.smf`
 or `NA32UI.smf` menu. When that SMF launches a child SMF through `StartGame`,
-pressing **ESC** during gameplay reloads the parent and restores its saved menu
-context. Internal `.ssl` scene changes remain part of the child game and do not
-add return levels. Pressing **ESC** on the initial menu exits the emulator.
+pressing **ESC** during gameplay reloads the parent as a fresh session.
+Internal `.ssl` scene changes remain part of the child game and do not add
+return levels. Pressing **ESC** on the initial menu exits the emulator.
 
 The same relationship-based behavior applies outside ZIP mode: a directly
 loaded SMF can launch a child and receive control again, while a directly


### PR DESCRIPTION
## Summary

Replace the ZIP-specific back target with relationship-based parent SMF navigation.

The ZIP entry-point whitelist remains responsible only for choosing the first file from an archive. Back behavior no longer depends on whether content came from a ZIP or whether the launcher is named `FHUI.smf` / `NA32UI.smf`.

## Design

- Add an explicit content-load kind:
  - `LaunchChild` for `StartGame`
  - `Replace` for `SSL_PlayNext` and NAV transitions
- Push a return frame only after a successful SMF-to-SMF child launch.
- Store parent SMF paths in a stack and unwind nested launches one level at a time.
- Keep SSL scene changes inside the current child application, so gameplay returns directly to the launcher rather than walking backward through levels.
- Reload the parent as a fresh SMF session on ESC / RetroPad Select; exit when no parent exists.
- Validate and initialize target content before mutating the running emulator state.

## Why parent reloads are fresh

`SaveContext` alone is not a complete suspended menu state: it does not include the parent VM, cloned sprites, list images, or input state. Replaying the saved context into a newly initialized `NA32UI.smf` skips the setup that creates its game list and leaves the menu unresponsive. A return therefore reloads the parent from its normal entry path without injecting the partial context.

This matches the emulator's existing reload architecture and works for both FHUI and NA32UI. Resuming the exact menu position would require storing and restoring the complete parent runtime snapshot, which is separate from path-based back navigation.

## Save-state behavior

- Serialize return targets as content-root-relative paths.
- Restore the full nested return stack during deserialization.
- Keep the save-state format version unchanged and use optional/defaulted fields so older states remain readable.
- Preserve the legacy ZIP fallback when loading an older state that predates the return-stack field.

## User-visible behavior

| Flow | Back action |
|---|---|
| Directly loaded SMF with no parent | Exit |
| `A.smf -> B.smf` through `StartGame` | Reload A as a fresh session |
| `A.smf -> B.smf -> C.smf` | C returns to B, then B returns to A |
| `A.smf -> B.smf -> *.ssl` | Return to A |
| `*.ssl -> *.ssl` | No additional return level |

This applies equally to direct SMF loading, standalone ZIP mode, and the libretro core.

## Documentation

Update the README, standalone ZIP-mode guide, and RetroArch return/exit guide to describe the relationship-based behavior, fresh parent reloads, and nested returns.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo build --workspace --release`
- `cargo test --workspace --all-targets`
- Real-asset smoke coverage for:
  - normal FHUI selection followed by returning to a responsive FHUI
  - directly loaded SMF child launch and fresh parent reload
  - nested SMF return-stack save/restore
  - NA32UI ZIP child launch and return
  - NA32UI selecting `POP/MagicalA.smf`, returning, rebuilding its game-list images, and accepting confirmation input again